### PR TITLE
 [JENKINS-51609] Filter report to show only low coverage code

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -41,7 +41,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/resources/io/jenkins/plugins/coverage/targets/CoverageResult/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/targets/CoverageResult/index.jelly
@@ -1,6 +1,5 @@
 <?jelly escape-by-default='false'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
     <l:layout css="/plugin/code-coverage-api/css/style.css" norefresh="true">
         <script src="${rootURL}/plugin/code-coverage-api/scripts/echarts.min.js">
         </script>


### PR DESCRIPTION
Data range handler now can filter coverage item, and it will reduce the number of coverage shown on the page.

**For example**, if we set range to [0, 100], it will show 20 items:
![screenshot from 2018-05-31 09-01-15](https://user-images.githubusercontent.com/22002278/40755833-b5b7f8d4-64b2-11e8-9f84-15e4e5a0f540.png)


If we set range to [0, 66], it will only show 4 items:
![screenshot from 2018-05-31 09-01-41](https://user-images.githubusercontent.com/22002278/40755863-e068e87c-64b2-11e8-976d-ffb18ba2709f.png)

The default range is set to [0, 75].
