### PR TITLE
[JENKINS-51499] Clean-up Licensenes in the adopted code

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/targets/Chartable.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/Chartable.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License
+ * Copyright (c) 2007-2018 Michael Barrientos, Seiji Sogabe and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ import hudson.model.Run;
 
 import java.util.Map;
 
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 public interface Chartable {
 
     Chartable getPreviousResult();

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageAggregationMode.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageAggregationMode.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License
+ * Copyright (c) 2007-2018 Stephen Connolly, Michael Barrientos, Jeff Pearce and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,8 @@
  */
 package io.jenkins.plugins.coverage.targets;
 
+
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 
 /**
  * Different ways of aggregating data series {x_1,x_2,x_3,...}, which can be represented as

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageAggregationRule.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageAggregationRule.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License
+ * Copyright (c) 2007-2018 Stephen Connolly, Seiji Sogabe, Shenyu Zheng and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@ import static io.jenkins.plugins.coverage.targets.CoverageAggregationMode.SUM;
 import static io.jenkins.plugins.coverage.targets.CoverageElement.*;
 import static io.jenkins.plugins.coverage.targets.CoverageMetric.*;
 
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 
 /**
  * Rules that determines how coverage ratio of children are aggregated into that of the parent.

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageChart.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageChart.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License
+ * Copyright (c) 2007-2018 Seiji Sogabe, Michael Barrientos, Balázs Póka, Jeff Pearce and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,7 @@ import org.jfree.ui.RectangleInsets;
 import java.awt.*;
 import java.util.Map;
 
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 public class CoverageChart {
     private CategoryDataset dataset;
     private int lowerBound;

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageElement.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageElement.java
@@ -1,4 +1,27 @@
+/*
+ * Copyright (c) 2007-2018 Stephen Connolly, manolo, Michael Barrientos, Shenyu Zheng and Jenkins contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.jenkins.plugins.coverage.targets;
+
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 
 /**
  * Type of program construct being covered.

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageMetric.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageMetric.java
@@ -1,4 +1,27 @@
+/*
+ * Copyright (c) 2007-2018 connollys, manolo, Seiji Sogabe, Michael Barrientos, Shenyu Zheng and Jenkins contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.jenkins.plugins.coverage.targets;
+
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 
 /**
  * @author connollys

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoveragePaint.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoveragePaint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007-2018 Stephen Connolly, Steven Christou, Jeff Pearce, Shenyu Cheng, and Jenkins contributors
+ * Copyright (c) 2007-2018 Stephen Connolly, Jesse Glick, Kohsuke Kawaguchi, Seiji Sogabe and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@ import java.util.EnumMap;
 import java.util.Map;
 
 // Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
+
 /**
  * Line-by-line coverage information.
  *

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoveragePaintRule.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoveragePaintRule.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License
+ * Copyright (c) 2007-2018 Stephen Connolly, Stephen Connolly and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,8 @@
 package io.jenkins.plugins.coverage.targets;
 
 import java.io.Serializable;
+
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 
 /**
  * Describes how {@link CoveragePaint} can be aggregated up a {@link CoverageResult} tree.

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License
+ * Copyright (c) 2007-2018 Stephen Connolly, Michael Barrientos, Jeff Pearce, Shenyu Zheng and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 
 /**
  * <p>Coverage result for a specific programming element.</p>

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTree.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTree.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License
+ * Copyright (c) 2007-2018 Seiji Sogabe, podarsmarty, Michael Barrientos and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,7 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Map.Entry;
 
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 @ExportedBean
 public class CoverageTree implements Serializable {
 

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTreeElement.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTreeElement.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License
+ * Copyright (c) 2007-2018 Seiji Sogabe, podarsmarty, Michael Barrientos and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 
 import java.io.Serializable;
 
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 @ExportedBean
 public class CoverageTreeElement implements Serializable {
 

--- a/src/main/java/io/jenkins/plugins/coverage/targets/HasName.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/HasName.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License
+ * Copyright (c) 2007-2018 manolo, Seiji Sogabe, Michael Barrientos and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,7 @@
  */
 package io.jenkins.plugins.coverage.targets;
 
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 /**
  * Interface for elements which have a display name
  *

--- a/src/main/java/io/jenkins/plugins/coverage/targets/Ratio.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/Ratio.java
@@ -1,5 +1,5 @@
 /*
- * The MIT License
+ * Copyright (c) 2007-2018 Kohsuke Kawaguchi, Michael Barrientos, Jeff Pearce, Shenyu Zheng and Jenkins contributors
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,8 @@ import java.io.Serializable;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+
+// Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
 
 /**
  * Represents <tt>x/y</tt> where x={@link #numerator} and y={@link #denominator}.


### PR DESCRIPTION
update the copyright holders according to the file contributors show in GitHub and @author annotation.