### PR TITLE
[JENKINS-51422] Offer REST API to retrieve the coverage reports in ma…

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -22,7 +22,6 @@
 package io.jenkins.plugins.coverage.targets;
 
 import hudson.model.AbstractBuild;
-import hudson.model.Api;
 import hudson.model.Item;
 import hudson.model.Run;
 import hudson.util.ChartUtil;
@@ -79,7 +78,7 @@ public class CoverageResult implements Serializable, Chartable {
     /**
      * The type of the programming element.
      */
-    private final CoverageElement   element;
+    private final CoverageElement element;
 
     /**
      * Name of the programming element that this result object represent, such as package name, class name, method name, etc.
@@ -322,10 +321,11 @@ public class CoverageResult implements Serializable, Chartable {
      */
     @Exported(name = "results")
     public CoverageTree getResultsAPI() {
-        return new CoverageTree(name, aggregateResults, children, getCoverageTrends());
+        return new CoverageTree(name, aggregateResults, children);
     }
 
-    public CoverageTrend[] getCoverageTrends() {
+    public List<CoverageTrend> getCoverageTrends() {
+
         if (getPreviousResult() == null) {
             return null;
         }
@@ -335,14 +335,14 @@ public class CoverageResult implements Serializable, Chartable {
         for (Chartable c = this; c != null && i < DEFAULT_MAX_BUILDS_SHOW_IN_TREND; c = c.getPreviousResult(), i++) {
             ChartUtil.NumberOnlyBuildLabel label = new ChartUtil.NumberOnlyBuildLabel(c.getOwner());
 
-            CoverageTreeElement[] elements = c.getResults().entrySet().stream()
+            List<CoverageTreeElement> elements = c.getResults().entrySet().stream()
                     .map(e -> new CoverageTreeElement(e.getKey(), e.getValue()))
-                    .toArray(CoverageTreeElement[]::new);
+                    .collect(Collectors.toList());
 
             CoverageTrend trend = new CoverageTrend(label.toString(), elements);
             coverageTrends.add(trend);
         }
-        return coverageTrends.toArray(new CoverageTrend[0]);
+        return coverageTrends;
     }
 
 
@@ -547,8 +547,8 @@ public class CoverageResult implements Serializable, Chartable {
         return result;
     }
 
-    public Api getApi() {
-        return new Api(this);
+    public RestfulCoverageResultWrapper getApi() {
+        return new RestfulCoverageResultWrapper(this);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -322,8 +322,29 @@ public class CoverageResult implements Serializable, Chartable {
      */
     @Exported(name = "results")
     public CoverageTree getResultsAPI() {
-        return new CoverageTree(name, aggregateResults, children);
+        return new CoverageTree(name, aggregateResults, children, getCoverageTrends());
     }
+
+    public CoverageTrend[] getCoverageTrends() {
+        if (getPreviousResult() == null) {
+            return null;
+        }
+
+        List<CoverageTrend> coverageTrends = new LinkedList<>();
+        int i = 0;
+        for (Chartable c = this; c != null && i < DEFAULT_MAX_BUILDS_SHOW_IN_TREND; c = c.getPreviousResult(), i++) {
+            ChartUtil.NumberOnlyBuildLabel label = new ChartUtil.NumberOnlyBuildLabel(c.getOwner());
+
+            CoverageTreeElement[] elements = c.getResults().entrySet().stream()
+                    .map(e -> new CoverageTreeElement(e.getKey(), e.getValue()))
+                    .toArray(CoverageTreeElement[]::new);
+
+            CoverageTrend trend = new CoverageTrend(label.toString(), elements);
+            coverageTrends.add(trend);
+        }
+        return coverageTrends.toArray(new CoverageTrend[0]);
+    }
+
 
     public String urlTransform(String name) {
         StringBuilder buf = new StringBuilder(name.length());

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTree.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTree.java
@@ -41,13 +41,16 @@ public class CoverageTree implements Serializable {
 
     private Map<String, CoverageResult> children;
 
+    private CoverageTrend[] trends;
+
     private String name;
 
     public CoverageTree(String name, Map<CoverageMetric, Ratio> aggregateResults,
-                        Map<String, CoverageResult> children) {
+                        Map<String, CoverageResult> children, CoverageTrend[] trends) {
         this.name = name;
         this.aggregateResults = aggregateResults;
         this.children = children;
+        this.trends = trends;
     }
 
     @Exported
@@ -71,9 +74,14 @@ public class CoverageTree implements Serializable {
         CoverageTree[] ct = new CoverageTree[children.size()];
         int current = 0;
         for (Entry<String, CoverageResult> e : children.entrySet()) {
-            ct[current] = new CoverageTree(e.getKey(), e.getValue().getResults(), e.getValue().getChildrenReal());
+            ct[current] = new CoverageTree(e.getKey(), e.getValue().getResults(), e.getValue().getChildrenReal(), e.getValue().getCoverageTrends());
             current++;
         }
         return ct;
+    }
+
+    @Exported
+    public CoverageTrend[] getTrends() {
+        return trends;
     }
 }

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTree.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTree.java
@@ -41,16 +41,14 @@ public class CoverageTree implements Serializable {
 
     private Map<String, CoverageResult> children;
 
-    private CoverageTrend[] trends;
 
     private String name;
 
     public CoverageTree(String name, Map<CoverageMetric, Ratio> aggregateResults,
-                        Map<String, CoverageResult> children, CoverageTrend[] trends) {
+                        Map<String, CoverageResult> children) {
         this.name = name;
         this.aggregateResults = aggregateResults;
         this.children = children;
-        this.trends = trends;
     }
 
     @Exported
@@ -74,14 +72,9 @@ public class CoverageTree implements Serializable {
         CoverageTree[] ct = new CoverageTree[children.size()];
         int current = 0;
         for (Entry<String, CoverageResult> e : children.entrySet()) {
-            ct[current] = new CoverageTree(e.getKey(), e.getValue().getResults(), e.getValue().getChildrenReal(), e.getValue().getCoverageTrends());
+            ct[current] = new CoverageTree(e.getKey(), e.getValue().getResults(), e.getValue().getChildrenReal());
             current++;
         }
         return ct;
-    }
-
-    @Exported
-    public CoverageTrend[] getTrends() {
-        return trends;
     }
 }

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTreeElement.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTreeElement.java
@@ -63,8 +63,4 @@ public class CoverageTreeElement implements Serializable {
     public float getDenominator() {
         return ratio.denominator;
     }
-
-    public Ratio getRealRatio() {
-        return ratio;
-    }
 }

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTreeElement.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTreeElement.java
@@ -27,7 +27,7 @@ import org.kohsuke.stapler.export.ExportedBean;
 import java.io.Serializable;
 
 // Code adopted from Cobertura Plugin https://github.com/jenkinsci/cobertura-plugin/
-@ExportedBean
+@ExportedBean(defaultVisibility = 2)
 public class CoverageTreeElement implements Serializable {
 
     /**
@@ -62,5 +62,9 @@ public class CoverageTreeElement implements Serializable {
     @Exported
     public float getDenominator() {
         return ratio.denominator;
+    }
+
+    public Ratio getRealRatio() {
+        return ratio;
     }
 }

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTrend.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTrend.java
@@ -4,15 +4,16 @@ import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
 import java.io.Serializable;
+import java.util.List;
 
 @ExportedBean
 public class CoverageTrend implements Serializable {
 
     private String buildName;
-    private CoverageTreeElement[] elements;
+    private List<CoverageTreeElement> elements;
 
 
-    public CoverageTrend(String buildName, CoverageTreeElement[] elements) {
+    public CoverageTrend(String buildName, List<CoverageTreeElement> elements) {
         this.buildName = buildName;
         this.elements = elements;
     }
@@ -23,7 +24,7 @@ public class CoverageTrend implements Serializable {
     }
 
     @Exported
-    public CoverageTreeElement[] getElements() {
+    public List<CoverageTreeElement> getElements() {
         return elements;
     }
 

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTrend.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTrend.java
@@ -1,0 +1,30 @@
+package io.jenkins.plugins.coverage.targets;
+
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import java.io.Serializable;
+
+@ExportedBean
+public class CoverageTrend implements Serializable {
+
+    private String buildName;
+    private CoverageTreeElement[] elements;
+
+
+    public CoverageTrend(String buildName, CoverageTreeElement[] elements) {
+        this.buildName = buildName;
+        this.elements = elements;
+    }
+
+    @Exported
+    public String getBuildName() {
+        return buildName;
+    }
+
+    @Exported
+    public CoverageTreeElement[] getElements() {
+        return elements;
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTrendTree.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTrendTree.java
@@ -1,0 +1,42 @@
+package io.jenkins.plugins.coverage.targets;
+
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+@ExportedBean
+public class CoverageTrendTree {
+
+    private String name;
+    private List<CoverageTrend> trends;
+    private Map<String, CoverageResult> children;
+
+    public CoverageTrendTree(String name, List<CoverageTrend> trends, Map<String, CoverageResult> children) {
+        this.name = name;
+        this.trends = trends;
+        this.children = children;
+    }
+
+    @Exported
+    public String getName() {
+        return name;
+    }
+
+    @Exported
+    public List<CoverageTrend> getTrends() {
+        return trends;
+    }
+
+    @Exported
+    public List<CoverageTrendTree> getChildren() {
+        List<CoverageTrendTree> childrenTrends = new LinkedList<>();
+
+        for (Map.Entry<String, CoverageResult> e : children.entrySet()) {
+            childrenTrends.add(new CoverageTrendTree(e.getKey(), e.getValue().getCoverageTrends(), e.getValue().getChildrenReal()));
+        }
+        return childrenTrends;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/coverage/targets/RestfulCoverageResultWrapper.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/RestfulCoverageResultWrapper.java
@@ -1,0 +1,30 @@
+package io.jenkins.plugins.coverage.targets;
+
+import hudson.model.Api;
+
+public class RestfulCoverageResultWrapper {
+
+    private CoverageResult result;
+
+    public RestfulCoverageResultWrapper(CoverageResult result) {
+        this.result = result;
+    }
+
+
+    public Api getResult() {
+        return new Api(result);
+    }
+
+    public Api getTrend() {
+        return new Api(new CoverageTrendTree(result.getName(), result.getCoverageTrends(), result.getChildrenReal()));
+    }
+
+    public Object getLast() {
+        CoverageResult previousResult = result.getPreviousResult();
+
+        if (previousResult != null)
+            return new RestfulCoverageResultWrapper(previousResult);
+        else
+            return null;
+    }
+}


### PR DESCRIPTION
…chine-readable format, [JENKINS-51423] Offer REST API to retrieve the coverage trends in machine-readable format.

Get coverage reports and coverage trends by REST API : 
`../job/{jobName}/{build}/coverage/api/{json|xml}`