### PR TITLE
[JENKINS-53130] Code coverage 0% in jenkins with Jacoco

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/adapter/JacocoReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/JacocoReportAdapter.java
@@ -1,8 +1,17 @@
 package io.jenkins.plugins.coverage.adapter;
 
 import hudson.Extension;
+import io.jenkins.plugins.coverage.adapter.parser.JavaCoverageParser;
+import io.jenkins.plugins.coverage.exception.CoverageException;
+import io.jenkins.plugins.coverage.targets.CoverageElement;
+import io.jenkins.plugins.coverage.targets.CoverageResult;
+import io.jenkins.plugins.coverage.targets.Ratio;
+import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import javax.annotation.Nonnull;
 
@@ -29,6 +38,12 @@ public final class JacocoReportAdapter extends JavaXMLCoverageReportAdapter {
         return null;
     }
 
+    @Override
+    public CoverageResult parseToResult(Document document, String reportName) throws CoverageException {
+        return new JacocoCoverageParser(reportName).parse(document);
+    }
+
+
     @Symbol("jacoco")
     @Extension
     public static final class JacocoReportAdapterDescriptor extends JavaCoverageReportAdapterDescriptor {
@@ -41,6 +56,56 @@ public final class JacocoReportAdapter extends JavaXMLCoverageReportAdapter {
         @Override
         public String getDisplayName() {
             return Messages.JacocoReportAdapter_displayName();
+        }
+    }
+
+
+    public static final class JacocoCoverageParser extends JavaCoverageParser {
+
+        public JacocoCoverageParser(String reportName) {
+            super(reportName);
+        }
+
+
+        @Override
+        protected CoverageResult processElement(Element current, CoverageResult parentResult) {
+            CoverageResult result = super.processElement(current, parentResult);
+
+            if (current.getLocalName().equals("method")) {
+
+                if (getAttribute(current, "attr-mode", null) != null) {
+                    String lineCoveredAttr = getAttribute(current, "line-covered", null);
+                    String lineMissedAttr = getAttribute(current, "line-missed", null);
+
+                    String branchCoveredAttr = getAttribute(current, "br-covered", null);
+                    String branchMissedAttr = getAttribute(current, "br-missed", null);
+
+                    if (StringUtils.isNumeric(lineCoveredAttr) && StringUtils.isNumeric(lineMissedAttr)) {
+                        int covered = Integer.parseInt(lineCoveredAttr);
+                        int missed = Integer.parseInt(lineMissedAttr);
+
+                        result.updateCoverage(CoverageElement.LINE, Ratio.create(covered, covered + missed));
+                    }
+
+                    if (StringUtils.isNumeric(branchCoveredAttr) && StringUtils.isNumeric(branchMissedAttr)) {
+                        int covered = Integer.parseInt(branchCoveredAttr);
+                        int missed = Integer.parseInt(branchMissedAttr);
+
+                        result.updateCoverage(CoverageElement.CONDITIONAL, Ratio.create(covered, covered + missed));
+                    }
+
+                    if (BooleanUtils.toBoolean(getAttribute(current, "covered", "false"))) {
+                        if (result.getResults().size() == 0) {
+                            parentResult.updateCoverage(CoverageElement.get("Method"), Ratio.create(1, 1));
+                        }
+                    }
+
+                    // return null to skip parsing children
+                    return null;
+
+                }
+            }
+            return result;
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/coverage/adapter/JacocoReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/JacocoReportAdapter.java
@@ -80,14 +80,14 @@ public final class JacocoReportAdapter extends JavaXMLCoverageReportAdapter {
             CoverageResult result = super.processElement(current, parentResult);
 
             if (getAttribute(current, "attr-mode", null) != null) {
-                String lineCoveredAttr = getAttribute(current, "line-covered", null);
-                String lineMissedAttr = getAttribute(current, "line-missed", null);
+                String lineCoveredAttr = getAttribute(current, "line-covered");
+                String lineMissedAttr = getAttribute(current, "line-missed");
 
-                String branchCoveredAttr = getAttribute(current, "br-covered", null);
-                String branchMissedAttr = getAttribute(current, "br-missed", null);
+                String branchCoveredAttr = getAttribute(current, "br-covered");
+                String branchMissedAttr = getAttribute(current, "br-missed");
 
-                String instructionCoveredAttr = getAttribute(current, "instruction-covered", null);
-                String instructionMissedAttr = getAttribute(current, "instruction-missed", null);
+                String instructionCoveredAttr = getAttribute(current, "instruction-covered");
+                String instructionMissedAttr = getAttribute(current, "instruction-missed");
 
                 if (StringUtils.isNumeric(lineCoveredAttr) && StringUtils.isNumeric(lineMissedAttr)) {
                     int covered = Integer.parseInt(lineCoveredAttr);

--- a/src/main/java/io/jenkins/plugins/coverage/adapter/JacocoReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/JacocoReportAdapter.java
@@ -14,6 +14,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 
 public final class JacocoReportAdapter extends JavaXMLCoverageReportAdapter {
 
@@ -57,6 +58,13 @@ public final class JacocoReportAdapter extends JavaXMLCoverageReportAdapter {
         public String getDisplayName() {
             return Messages.JacocoReportAdapter_displayName();
         }
+
+        @Override
+        public List<CoverageElement> getCoverageElements() {
+            List<CoverageElement> registerCoverageElements = super.getCoverageElements();
+            registerCoverageElements.add(new CoverageElement("Instruction", 5));
+            return registerCoverageElements;
+        }
     }
 
 
@@ -71,40 +79,39 @@ public final class JacocoReportAdapter extends JavaXMLCoverageReportAdapter {
         protected CoverageResult processElement(Element current, CoverageResult parentResult) {
             CoverageResult result = super.processElement(current, parentResult);
 
-            if (current.getLocalName().equals("method")) {
+            if (getAttribute(current, "attr-mode", null) != null) {
+                String lineCoveredAttr = getAttribute(current, "line-covered", null);
+                String lineMissedAttr = getAttribute(current, "line-missed", null);
 
-                if (getAttribute(current, "attr-mode", null) != null) {
-                    String lineCoveredAttr = getAttribute(current, "line-covered", null);
-                    String lineMissedAttr = getAttribute(current, "line-missed", null);
+                String branchCoveredAttr = getAttribute(current, "br-covered", null);
+                String branchMissedAttr = getAttribute(current, "br-missed", null);
 
-                    String branchCoveredAttr = getAttribute(current, "br-covered", null);
-                    String branchMissedAttr = getAttribute(current, "br-missed", null);
+                String instructionCoveredAttr = getAttribute(current, "instruction-covered", null);
+                String instructionMissedAttr = getAttribute(current, "instruction-missed", null);
 
-                    if (StringUtils.isNumeric(lineCoveredAttr) && StringUtils.isNumeric(lineMissedAttr)) {
-                        int covered = Integer.parseInt(lineCoveredAttr);
-                        int missed = Integer.parseInt(lineMissedAttr);
+                if (StringUtils.isNumeric(lineCoveredAttr) && StringUtils.isNumeric(lineMissedAttr)) {
+                    int covered = Integer.parseInt(lineCoveredAttr);
+                    int missed = Integer.parseInt(lineMissedAttr);
 
-                        result.updateCoverage(CoverageElement.LINE, Ratio.create(covered, covered + missed));
-                    }
-
-                    if (StringUtils.isNumeric(branchCoveredAttr) && StringUtils.isNumeric(branchMissedAttr)) {
-                        int covered = Integer.parseInt(branchCoveredAttr);
-                        int missed = Integer.parseInt(branchMissedAttr);
-
-                        result.updateCoverage(CoverageElement.CONDITIONAL, Ratio.create(covered, covered + missed));
-                    }
-
-                    if (BooleanUtils.toBoolean(getAttribute(current, "covered", "false"))) {
-                        if (result.getResults().size() == 0) {
-                            parentResult.updateCoverage(CoverageElement.get("Method"), Ratio.create(1, 1));
-                        }
-                    }
-
-                    // return null to skip parsing children
-                    return null;
-
+                    result.updateCoverage(CoverageElement.LINE, Ratio.create(covered, covered + missed));
                 }
+
+                if (StringUtils.isNumeric(branchCoveredAttr) && StringUtils.isNumeric(branchMissedAttr)) {
+                    int covered = Integer.parseInt(branchCoveredAttr);
+                    int missed = Integer.parseInt(branchMissedAttr);
+
+                    result.updateCoverage(CoverageElement.CONDITIONAL, Ratio.create(covered, covered + missed));
+                }
+
+                if(StringUtils.isNumeric(instructionCoveredAttr) && StringUtils.isNumeric(instructionMissedAttr)) {
+                    int covered = Integer.parseInt(instructionCoveredAttr);
+                    int missed = Integer.parseInt(instructionMissedAttr);
+
+                    result.updateCoverage(CoverageElement.get("Instruction"), Ratio.create(covered, covered + missed));
+                }
+
             }
+
             return result;
         }
     }

--- a/src/main/java/io/jenkins/plugins/coverage/adapter/JavaCoverageReportAdapterDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/JavaCoverageReportAdapterDescriptor.java
@@ -1,8 +1,8 @@
 package io.jenkins.plugins.coverage.adapter;
 
+import com.google.common.collect.Lists;
 import io.jenkins.plugins.coverage.targets.CoverageElement;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class JavaCoverageReportAdapterDescriptor extends CoverageReportAdapterDescriptor<CoverageReportAdapter> {
@@ -13,7 +13,7 @@ public class JavaCoverageReportAdapterDescriptor extends CoverageReportAdapterDe
 
     @Override
     public List<CoverageElement> getCoverageElements() {
-        return Arrays.asList(new CoverageElement("Group", 0),
+        return Lists.newArrayList(new CoverageElement("Group", 0),
                 new CoverageElement("Package", 1),
                 new CoverageElement("File", 2),
                 new CoverageElement("Class", 3),

--- a/src/main/java/io/jenkins/plugins/coverage/adapter/parser/CoverageParser.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/parser/CoverageParser.java
@@ -63,6 +63,9 @@ public abstract class CoverageParser {
             Node n = nodeList.item(i);
             if (n.getNodeType() == Node.ELEMENT_NODE) {
                 CoverageResult r = processElement((Element) n, parentResult);
+                if(r == null) {
+                    continue;
+                }
                 parse(n, r);
             }
         }

--- a/src/main/java/io/jenkins/plugins/coverage/adapter/parser/CoverageParser.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/parser/CoverageParser.java
@@ -63,7 +63,7 @@ public abstract class CoverageParser {
             Node n = nodeList.item(i);
             if (n.getNodeType() == Node.ELEMENT_NODE) {
                 CoverageResult r = processElement((Element) n, parentResult);
-                if(r == null) {
+                if (r == null) {
                     continue;
                 }
                 parse(n, r);
@@ -102,6 +102,15 @@ public abstract class CoverageParser {
     protected String getAttribute(Element e, String attributeName, String defaultValue) {
         String value = e.getAttribute(attributeName);
         return StringUtils.isEmpty(value) ? defaultValue : value;
+    }
+
+    /**
+     * @param e             element
+     * @param attributeName attribute name
+     * @return value of attribute, or <code>null</code> if attribute not exists.
+     */
+    protected String getAttribute(Element e, String attributeName) {
+        return getAttribute(e, attributeName, null);
     }
 
     protected void processLine(Element current, CoverageResult parentResult) {

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageAggregationRule.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageAggregationRule.java
@@ -21,17 +21,6 @@ public class CoverageAggregationRule {
         Ratio r = Ratio.create(inputResult.numerator + prevTotal.numerator, inputResult.denominator + prevTotal.denominator);
         result.put(input, r);
 
-        if (input.equals(CoverageElement.LINE)) {
-            prevTotal = result.get(source);
-            if (prevTotal == null) {
-                prevTotal = Ratio.create(0, 0);
-            }
-
-            r = Ratio.create(prevTotal.numerator + (Math.abs(inputResult.numerator) > 1e-7 ? 1 : 0), prevTotal.denominator + 1);
-            result.put(source, r);
-
-        }
-
         return result;
     }
 

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -428,13 +428,24 @@ public class CoverageResult implements Serializable, Chartable {
                 aggregateResults.putAll(CoverageAggregationRule.aggregate(child.getElement(),
                         childResult.getKey(), childResult.getValue(), aggregateResults));
             }
+
+            Ratio prevTotal = aggregateResults.get(child.getElement());
+            if (prevTotal == null) {
+                prevTotal = Ratio.create(0, 0);
+            }
+
+            boolean isChildCovered = false;
+
+            if (child.aggregateResults.entrySet().stream().anyMatch(coverageElementRatioEntry ->
+                    coverageElementRatioEntry.getValue().numerator > 0)) {
+                isChildCovered = true;
+            }
+
+            aggregateResults.put(child.getElement(), Ratio.create(prevTotal.numerator + (isChildCovered ? 1 : 0), prevTotal.denominator + 1));
         }
-        // override any local results (as they should be more accurate than the aggregated ones)
+
+        // override any local results
         aggregateResults.putAll(localResults);
-        // now inject any results from CoveragePaint as they should be most accurate.
-        if (paint != null) {
-            aggregateResults.putAll(paint.getResults());
-        }
     }
 
     public void setOwner(AbstractBuild<?, ?> owner) {

--- a/src/main/resources/io/jenkins/plugins/coverage/adapter/jacoco-to-standard.xsl
+++ b/src/main/resources/io/jenkins/plugins/coverage/adapter/jacoco-to-standard.xsl
@@ -73,41 +73,71 @@
 
 
             <xsl:variable name="start" select="@line"/>
-            <xsl:variable name="LINE" select="'LINE'"/>
             <xsl:variable name="lines"
-                          select="number(counter[@type = $LINE]/@missed)  + number(counter[@type = $LINE]/@covered)"/>
-            <xsl:for-each select="../../sourcefile[@name = $filename]/line[@nr >= $start]">
-                <xsl:if test="not(position() > $lines)">
-                    <line>
-                        <xsl:attribute name="number">
-                            <xsl:value-of select="./@nr"/>
-                        </xsl:attribute>
-                        <xsl:attribute name="hits">
-                            <xsl:choose>
-                                <xsl:when test="./@ci > 0">1</xsl:when>
-                                <xsl:otherwise>0</xsl:otherwise>
-                            </xsl:choose>
-                        </xsl:attribute>
-                        <xsl:choose>
-                            <xsl:when test="number(./@mb) + number(./@cb) > 0 ">
-                                <xsl:attribute name="branch">true</xsl:attribute>
-                                <xsl:variable name="percentage"
-                                              select="number(./@cb) div (number(./@cb) + number(./@mb))"/>
-                                <xsl:attribute name="condition-coverage">
-                                    <xsl:value-of select="concat($percentage * 100, '% (')"/><xsl:value-of
-                                        select="concat(./@cb, '/', number(./@mb) + number(./@cb),')')"/>
-                                </xsl:attribute>
+                          select="number(counter[@type = 'LINE']/@missed)  + number(counter[@type = 'LINE']/@covered)"/>
+            <xsl:variable name="branchAttr" select="counter[@type = 'BRANCH']"/>
 
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:attribute name="branch">false</xsl:attribute>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </line>
-                </xsl:if>
-            </xsl:for-each>
+            <xsl:choose>
+                <xsl:when
+                        test="(../../sourcefile[@name = $filename]) and (../../sourcefile[@name = $filename]/line[@nr = $start]/following-sibling::line[$lines]) ">
+                    <xsl:for-each select="../../sourcefile[@name = $filename]/line[@nr >= $start]">
+                        <xsl:if test="not(position() > $lines)">
+                            <line>
+                                <xsl:attribute name="number">
+                                    <xsl:value-of select="./@nr"/>
+                                </xsl:attribute>
+                                <xsl:attribute name="hits">
+                                    <xsl:choose>
+                                        <xsl:when test="./@ci > 0">1</xsl:when>
+                                        <xsl:otherwise>0</xsl:otherwise>
+                                    </xsl:choose>
+                                </xsl:attribute>
+                                <xsl:choose>
+                                    <xsl:when test="$branchAttr and number(./@mb) + number(./@cb) > 0 ">
+                                        <xsl:attribute name="branch">true</xsl:attribute>
+                                        <xsl:variable name="percentage"
+                                                      select="number(./@cb) div (number(./@cb) + number(./@mb))"/>
+                                        <xsl:attribute name="condition-coverage">
+                                            <xsl:value-of select="concat($percentage * 100, '% (')"/><xsl:value-of
+                                                select="concat(./@cb, '/', number(./@mb) + number(./@cb),')')"/>
+                                        </xsl:attribute>
+
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:attribute name="branch">false</xsl:attribute>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </line>
+                        </xsl:if>
+                    </xsl:for-each>
+                </xsl:when>
+                <xsl:when test="not(counter[@type = 'LINE'])">
+                    <xsl:if test="number(counter[@type = 'METHOD']/@covered) > 0">
+                        <xsl:attribute name="attr-mode">true</xsl:attribute>
+                        <xsl:attribute name="covered">true</xsl:attribute>
+                    </xsl:if>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:attribute name="attr-mode">true</xsl:attribute>
+                    <xsl:attribute name="line-covered">
+                        <xsl:value-of select="counter[@type = 'LINE']/@covered">
+                        </xsl:value-of>
+                    </xsl:attribute>
+                    <xsl:attribute name="line-missed">
+                        <xsl:value-of select="counter[@type = 'LINE']/@missed">
+                        </xsl:value-of>
+                    </xsl:attribute>
+                    <xsl:if test="counter[@type = 'BRANCH']">
+                        <xsl:attribute name="br-covered">
+                            <xsl:value-of select="counter[@type = 'BRANCH']/@covered"/>
+                        </xsl:attribute>
+                        <xsl:attribute name="br-missed">
+                            <xsl:value-of select="counter[@type = 'BRANCH']/@missed"/>
+                        </xsl:attribute>
+                    </xsl:if>
+                </xsl:otherwise>
+            </xsl:choose>
         </method>
     </xsl:template>
-
 
 </xsl:stylesheet>

--- a/src/main/resources/io/jenkins/plugins/coverage/adapter/jacoco-to-standard.xsl
+++ b/src/main/resources/io/jenkins/plugins/coverage/adapter/jacoco-to-standard.xsl
@@ -106,7 +106,34 @@
                         </class>
                     </xsl:for-each>
 
-                    <xsl:copy-of select="../sourcefile[@name = $sourcefilename]/line"/>
+                    <xsl:for-each select="../sourcefile[@name = $sourcefilename]/line">
+                        <line>
+                            <xsl:attribute name="number">
+                                <xsl:value-of select="./@nr"/>
+                            </xsl:attribute>
+                            <xsl:attribute name="hits">
+                                <xsl:choose>
+                                    <xsl:when test="./@ci > 0">1</xsl:when>
+                                    <xsl:otherwise>0</xsl:otherwise>
+                                </xsl:choose>
+                            </xsl:attribute>
+                            <xsl:choose>
+                                <xsl:when test="number(./@mb) + number(./@cb) > 0 ">
+                                    <xsl:attribute name="branch">true</xsl:attribute>
+                                    <xsl:variable name="percentage"
+                                                  select="number(./@cb) div (number(./@cb) + number(./@mb))"/>
+                                    <xsl:attribute name="condition-coverage">
+                                        <xsl:value-of select="concat($percentage * 100, '% (')"/><xsl:value-of
+                                            select="concat(./@cb, '/', ./@mb,')')"/>
+                                    </xsl:attribute>
+
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:attribute name="branch">false</xsl:attribute>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </line>
+                    </xsl:for-each>
                 </file>
             </xsl:when>
             <xsl:otherwise>
@@ -153,7 +180,33 @@
                                 </class>
                             </xsl:for-each>
 
-                            <xsl:copy-of select="$sourcefile/line"/>
+                            <xsl:for-each select="$sourcefile/line">
+                                <line>
+                                    <xsl:attribute name="number">
+                                        <xsl:value-of select="./@nr"/>
+                                    </xsl:attribute>
+                                    <xsl:attribute name="hits">
+                                        <xsl:choose>
+                                            <xsl:when test="./@ci > 0">1</xsl:when>
+                                            <xsl:otherwise>0</xsl:otherwise>
+                                        </xsl:choose>
+                                    </xsl:attribute>
+                                    <xsl:choose>
+                                        <xsl:when test="number(./@mb) + number(./@cb) > 0 ">
+                                            <xsl:attribute name="branch">true</xsl:attribute>
+                                            <xsl:variable name="percentage"
+                                                          select="number(./@cb) div (number(./@cb) + number(./@mb))"/>
+                                            <xsl:attribute name="condition-coverage">
+                                                <xsl:value-of select="concat($percentage * 100, '% (')"/><xsl:value-of
+                                                    select="concat(./@cb, '/', ./@mb,')')"/>
+                                            </xsl:attribute>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:attribute name="branch">false</xsl:attribute>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                </line>
+                            </xsl:for-each>
                         </file>
                     </xsl:when>
                     <xsl:otherwise>

--- a/src/main/resources/io/jenkins/plugins/coverage/adapter/jacoco-to-standard.xsl
+++ b/src/main/resources/io/jenkins/plugins/coverage/adapter/jacoco-to-standard.xsl
@@ -2,8 +2,8 @@
 
     <xsl:output method="xml"/>
 
-    <xsl:key name="filename" match="class" use="substring-before(concat(@name, '$'), '$')"/>
-
+    <xsl:key name="classname" match="class" use="substring-before(concat(@name, '$'), '$')"/>
+    <xsl:key name="sourcefilename" match="class" use="@sourcefilename"/>
 
     <xsl:template match="/">
         <xsl:if test="/report">
@@ -38,25 +38,162 @@
             <xsl:attribute name="name">
                 <xsl:value-of select="@name"/>
             </xsl:attribute>
+
+            <xsl:attribute name="attr-mode">true</xsl:attribute>
+            <xsl:attribute name="instruction-covered">
+                <xsl:value-of select="counter[@type = 'INSTRUCTION']/@covered"/>
+            </xsl:attribute>
+            <xsl:attribute name="instruction-missed">
+                <xsl:value-of select="counter[@type = 'INSTRUCTION']/@missed"/>
+            </xsl:attribute>
+            <xsl:attribute name="line-covered">
+                <xsl:value-of select="counter[@type = 'LINE']/@covered"/>
+            </xsl:attribute>
+            <xsl:attribute name="line-missed">
+                <xsl:value-of select="counter[@type = 'LINE']/@missed"/>
+            </xsl:attribute>
+            <xsl:if test="counter[@type = 'BRANCH']">
+                <xsl:attribute name="br-covered">
+                    <xsl:value-of select="counter[@type = 'BRANCH']/@covered"/>
+                </xsl:attribute>
+                <xsl:attribute name="br-missed">
+                    <xsl:value-of select="counter[@type = 'BRANCH']/@missed"/>
+                </xsl:attribute>
+            </xsl:if>
+
             <xsl:apply-templates
-                    select="class[generate-id(.)=generate-id(key('filename',substring-before(concat(@name, '$'), '$'))[1])]"/>
+                    select="class[generate-id(.)=generate-id(key('classname',substring-before(concat(@name, '$'), '$'))[1])]"/>
         </package>
     </xsl:template>
 
 
     <xsl:template match="class">
-        <file name="{substring-before(concat(@name, '$'), '$')}.java">
-            <xsl:for-each select="key('filename',substring-before(concat(@name, '$'), '$'))">
-                <class>
-                    <xsl:attribute name="name">
-                        <xsl:value-of select="@name"/>
-                    </xsl:attribute>
+        <xsl:choose>
+            <xsl:when test="@sourcefilename">
+                <xsl:variable name="sourcefilename" select="@sourcefilename"/>
 
+                <file name="{$sourcefilename}">
+                    <xsl:for-each select="key('sourcefilename', $sourcefilename)">
+                        <class>
+                            <xsl:attribute name="name">
+                                <xsl:value-of select="@name"/>
+                            </xsl:attribute>
 
-                    <xsl:apply-templates select="method"/>
-                </class>
-            </xsl:for-each>
-        </file>
+                            <xsl:attribute name="attr-mode">true</xsl:attribute>
+                            <xsl:attribute name="instruction-covered">
+                                <xsl:value-of select="counter[@type = 'INSTRUCTION']/@covered"/>
+                            </xsl:attribute>
+                            <xsl:attribute name="instruction-missed">
+                                <xsl:value-of select="counter[@type = 'INSTRUCTION']/@missed"/>
+                            </xsl:attribute>
+                            <xsl:attribute name="line-covered">
+                                <xsl:value-of select="counter[@type = 'LINE']/@covered"/>
+                            </xsl:attribute>
+                            <xsl:attribute name="line-missed">
+                                <xsl:value-of select="counter[@type = 'LINE']/@missed"/>
+                            </xsl:attribute>
+                            <xsl:if test="counter[@type = 'BRANCH']">
+                                <xsl:attribute name="br-covered">
+                                    <xsl:value-of select="counter[@type = 'BRANCH']/@covered"/>
+                                </xsl:attribute>
+                                <xsl:attribute name="br-missed">
+                                    <xsl:value-of select="counter[@type = 'BRANCH']/@missed"/>
+                                </xsl:attribute>
+                            </xsl:if>
+
+                            <xsl:apply-templates select="method"/>
+
+                        </class>
+                    </xsl:for-each>
+
+                    <xsl:copy-of select="../sourcefile[@name = $sourcefilename]/line"/>
+                </file>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:variable name="classname"
+                              select="substring-after(substring-before(concat(@name, '$'), '$'), concat(../@name, '/'))"/>
+
+                <xsl:variable name="sourcefile" select="../sourcefile[starts-with(@name, concat($classname, '.'))]"/>
+                <xsl:choose>
+                    <xsl:when test="$sourcefile">
+                        <file name="{substring-before(concat(@name, '$'), '$')}.java">
+                            <xsl:attribute name="name">
+                                <xsl:value-of select="$sourcefile/@name"/>
+                            </xsl:attribute>
+
+                            <xsl:for-each select="key('classname',substring-before(concat(@name, '$'), '$'))">
+                                <class>
+                                    <xsl:attribute name="name">
+                                        <xsl:value-of select="@name"/>
+                                    </xsl:attribute>
+
+                                    <xsl:attribute name="attr-mode">true</xsl:attribute>
+                                    <xsl:attribute name="instruction-covered">
+                                        <xsl:value-of select="counter[@type = 'INSTRUCTION']/@covered"/>
+                                    </xsl:attribute>
+                                    <xsl:attribute name="instruction-missed">
+                                        <xsl:value-of select="counter[@type = 'INSTRUCTION']/@missed"/>
+                                    </xsl:attribute>
+                                    <xsl:attribute name="line-covered">
+                                        <xsl:value-of select="counter[@type = 'LINE']/@covered"/>
+                                    </xsl:attribute>
+                                    <xsl:attribute name="line-missed">
+                                        <xsl:value-of select="counter[@type = 'LINE']/@missed"/>
+                                    </xsl:attribute>
+                                    <xsl:if test="counter[@type = 'BRANCH']">
+                                        <xsl:attribute name="br-covered">
+                                            <xsl:value-of select="counter[@type = 'BRANCH']/@covered"/>
+                                        </xsl:attribute>
+                                        <xsl:attribute name="br-missed">
+                                            <xsl:value-of select="counter[@type = 'BRANCH']/@missed"/>
+                                        </xsl:attribute>
+                                    </xsl:if>
+
+                                    <xsl:apply-templates select="method"/>
+                                </class>
+                            </xsl:for-each>
+
+                            <xsl:copy-of select="$sourcefile/line"/>
+                        </file>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <file name="{$classname}.java">
+                            <xsl:for-each select="key('classname',substring-before(concat(@name, '$'), '$'))">
+                                <class>
+                                    <xsl:attribute name="name">
+                                        <xsl:value-of select="@name"/>
+                                    </xsl:attribute>
+
+                                    <xsl:attribute name="attr-mode">true</xsl:attribute>
+                                    <xsl:attribute name="instruction-covered">
+                                        <xsl:value-of select="counter[@type = 'INSTRUCTION']/@covered"/>
+                                    </xsl:attribute>
+                                    <xsl:attribute name="instruction-missed">
+                                        <xsl:value-of select="counter[@type = 'INSTRUCTION']/@missed"/>
+                                    </xsl:attribute>
+                                    <xsl:attribute name="line-covered">
+                                        <xsl:value-of select="counter[@type = 'LINE']/@covered"/>
+                                    </xsl:attribute>
+                                    <xsl:attribute name="line-missed">
+                                        <xsl:value-of select="counter[@type = 'LINE']/@missed"/>
+                                    </xsl:attribute>
+                                    <xsl:if test="counter[@type = 'BRANCH']">
+                                        <xsl:attribute name="br-covered">
+                                            <xsl:value-of select="counter[@type = 'BRANCH']/@covered"/>
+                                        </xsl:attribute>
+                                        <xsl:attribute name="br-missed">
+                                            <xsl:value-of select="counter[@type = 'BRANCH']/@missed"/>
+                                        </xsl:attribute>
+                                    </xsl:if>
+
+                                    <xsl:apply-templates select="method"/>
+                                </class>
+                            </xsl:for-each>
+                        </file>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
 
@@ -68,75 +205,28 @@
             <xsl:attribute name="signature">
                 <xsl:value-of select="@desc"/>
             </xsl:attribute>
-            <xsl:variable name="filename"
-                          select="substring-after(concat(substring-before(concat(parent::class/@name, '$'), '$'),'.java'), concat(../../@name, '/'))"/>
+            <xsl:attribute name="attr-mode">true</xsl:attribute>
+            <xsl:attribute name="instruction-covered">
+                <xsl:value-of select="counter[@type = 'INSTRUCTION']/@covered"/>
+            </xsl:attribute>
+            <xsl:attribute name="instruction-missed">
+                <xsl:value-of select="counter[@type = 'INSTRUCTION']/@missed"/>
+            </xsl:attribute>
+            <xsl:attribute name="line-covered">
+                <xsl:value-of select="counter[@type = 'LINE']/@covered"/>
+            </xsl:attribute>
+            <xsl:attribute name="line-missed">
+                <xsl:value-of select="counter[@type = 'LINE']/@missed"/>
+            </xsl:attribute>
+            <xsl:if test="counter[@type = 'BRANCH']">
+                <xsl:attribute name="br-covered">
+                    <xsl:value-of select="counter[@type = 'BRANCH']/@covered"/>
+                </xsl:attribute>
+                <xsl:attribute name="br-missed">
+                    <xsl:value-of select="counter[@type = 'BRANCH']/@missed"/>
+                </xsl:attribute>
+            </xsl:if>
 
-
-            <xsl:variable name="start" select="@line"/>
-            <xsl:variable name="lines"
-                          select="number(counter[@type = 'LINE']/@missed)  + number(counter[@type = 'LINE']/@covered)"/>
-            <xsl:variable name="branchAttr" select="counter[@type = 'BRANCH']"/>
-
-            <xsl:choose>
-                <xsl:when
-                        test="(../../sourcefile[@name = $filename]) and (../../sourcefile[@name = $filename]/line[@nr = $start]/following-sibling::line[$lines]) ">
-                    <xsl:for-each select="../../sourcefile[@name = $filename]/line[@nr >= $start]">
-                        <xsl:if test="not(position() > $lines)">
-                            <line>
-                                <xsl:attribute name="number">
-                                    <xsl:value-of select="./@nr"/>
-                                </xsl:attribute>
-                                <xsl:attribute name="hits">
-                                    <xsl:choose>
-                                        <xsl:when test="./@ci > 0">1</xsl:when>
-                                        <xsl:otherwise>0</xsl:otherwise>
-                                    </xsl:choose>
-                                </xsl:attribute>
-                                <xsl:choose>
-                                    <xsl:when test="$branchAttr and number(./@mb) + number(./@cb) > 0 ">
-                                        <xsl:attribute name="branch">true</xsl:attribute>
-                                        <xsl:variable name="percentage"
-                                                      select="number(./@cb) div (number(./@cb) + number(./@mb))"/>
-                                        <xsl:attribute name="condition-coverage">
-                                            <xsl:value-of select="concat($percentage * 100, '% (')"/><xsl:value-of
-                                                select="concat(./@cb, '/', number(./@mb) + number(./@cb),')')"/>
-                                        </xsl:attribute>
-
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <xsl:attribute name="branch">false</xsl:attribute>
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                            </line>
-                        </xsl:if>
-                    </xsl:for-each>
-                </xsl:when>
-                <xsl:when test="not(counter[@type = 'LINE'])">
-                    <xsl:if test="number(counter[@type = 'METHOD']/@covered) > 0">
-                        <xsl:attribute name="attr-mode">true</xsl:attribute>
-                        <xsl:attribute name="covered">true</xsl:attribute>
-                    </xsl:if>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:attribute name="attr-mode">true</xsl:attribute>
-                    <xsl:attribute name="line-covered">
-                        <xsl:value-of select="counter[@type = 'LINE']/@covered">
-                        </xsl:value-of>
-                    </xsl:attribute>
-                    <xsl:attribute name="line-missed">
-                        <xsl:value-of select="counter[@type = 'LINE']/@missed">
-                        </xsl:value-of>
-                    </xsl:attribute>
-                    <xsl:if test="counter[@type = 'BRANCH']">
-                        <xsl:attribute name="br-covered">
-                            <xsl:value-of select="counter[@type = 'BRANCH']/@covered"/>
-                        </xsl:attribute>
-                        <xsl:attribute name="br-missed">
-                            <xsl:value-of select="counter[@type = 'BRANCH']/@missed"/>
-                        </xsl:attribute>
-                    </xsl:if>
-                </xsl:otherwise>
-            </xsl:choose>
         </method>
     </xsl:template>
 


### PR DESCRIPTION
background: https://github.com/jenkinsci/code-coverage-api-plugin/issues/44

Add `attr-mode` which will read line coverage from attribute instead of child line elements.