### PR TITLE
Fixed support for multiple coverage files

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -178,7 +178,7 @@ public class CoverageProcessor {
                     //if copy exist, it means there have reports have same name.
                     int i = 1;
                     while (copy.exists()) {
-                        copy = new File(copy.getName() + i++);
+                        copy = new File(runRootDir, f.getBaseName() + i++);
                     }
 
                     f.copyTo(new FilePath(copy));


### PR DESCRIPTION
In case of multiple coverage files, the plugin tries to copy them to /jacoco1 where it usually does not have any access. Generating the names of the additional files (with number appended) in the same way as the original file name fixed it for me. Then I at least get a working summary of all coverages.

Keep up the good work with the plugin, we really need a new, flexible coverage plugin for Jenkins.