### PR TITLE
Show diff in coverage for change request builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ temp/
 work/
 *.iml
 .idea/
+bin/

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,17 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.7</version>
+            <version>1.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>scm-api</artifactId>
+            <version>2.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/io/jenkins/plugins/coverage/CoveragePublisher.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoveragePublisher.java
@@ -49,6 +49,8 @@ public class CoveragePublisher extends Recorder implements SimpleBuildStep {
 
     private String tag;
 
+    private boolean calculateDiffForChangeRequests = false;
+
     @DataBoundConstructor
     public CoveragePublisher() {
     }
@@ -80,6 +82,7 @@ public class CoveragePublisher extends Recorder implements SimpleBuildStep {
 
 
         processor.setGlobalTag(tag);
+        processor.setCalculateDiffForChangeRequests(calculateDiffForChangeRequests);
         processor.setFailUnhealthy(failUnhealthy);
         processor.setFailUnstable(failUnstable);
         processor.setFailNoReports(failNoReports);
@@ -163,6 +166,15 @@ public class CoveragePublisher extends Recorder implements SimpleBuildStep {
     @DataBoundSetter
     public void setTag(String tag) {
         this.tag = tag;
+    }
+
+    public boolean getCalculateDiffForChangeRequests() {
+        return calculateDiffForChangeRequests;
+    }
+
+    @DataBoundSetter
+    public void setCalculateDiffForChangeRequests(boolean calculateDiffForChangeRequests) {
+        this.calculateDiffForChangeRequests = calculateDiffForChangeRequests;
     }
 
     @Symbol("publishCoverage")

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -74,6 +74,11 @@ public class CoverageResult implements Serializable, Chartable {
     private String name;
     private String tag;
 
+    /**
+     * Properties to store a change request coverage diff with the latest successful build from the target branch
+     */
+    private float changeRequestCoverageDiffWithTargetBranch = 0;
+    private String linkToBuildThatWasUsedForComparison = null;
 
     // these two pointers form a tree structure where edges are names.
     private CoverageResult parent;
@@ -205,6 +210,42 @@ public class CoverageResult implements Serializable, Chartable {
             return new File(owner.getRootDir(), DefaultSourceFileResolver.DEFAULT_SOURCE_CODE_STORE_DIRECTORY + relativeSourcePath);
         }
         return null;
+    }
+
+    /**
+     * Getter for property 'changeRequestCoverageDiffWithTargetBranch'.
+     *
+     * @return Value for property 'changeRequestCoverageDiffWithTargetBranch'.
+     */
+    public float getChangeRequestCoverageDiffWithTargetBranch() {
+        return changeRequestCoverageDiffWithTargetBranch;
+    }
+
+    /**
+     * Setter for property 'changeRequestCoverageDiffWithTargetBranch'.
+     *
+     * @param changeRequestCoverageDiffWithTargetBranch Value to set for property 'changeRequestCoverageDiffWithTargetBranch'.
+     */
+    public void setChangeRequestCoverageDiffWithTargetBranch(float changeRequestCoverageDiffWithTargetBranch) {
+        this.changeRequestCoverageDiffWithTargetBranch = changeRequestCoverageDiffWithTargetBranch;
+    }
+
+    /**
+     * Getter for property 'linkToBuildThatWasUsedForComparison'.
+     *
+     * @return Value for property 'linkToBuildThatWasUsedForComparison'.
+     */
+    public String getLinkToBuildThatWasUsedForComparison() {
+        return linkToBuildThatWasUsedForComparison;
+    }
+
+    /**
+     * Setter for property 'linkToBuildThatWasUsedForComparison'.
+     *
+     * @param linkToBuildThatWasUsedForComparison Value to set for property 'linkToBuildThatWasUsedForComparison'.
+     */
+    public void setLinkToBuildThatWasUsedForComparison(String linkToBuildThatWasUsedForComparison) {
+        this.linkToBuildThatWasUsedForComparison = linkToBuildThatWasUsedForComparison;
     }
 
     /**

--- a/src/main/resources/io/jenkins/plugins/coverage/CoverageAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/CoverageAction/summary.jelly
@@ -5,6 +5,29 @@
         <j:set var="result" value="${it.target}" />
         <j:if test="${result != null}">
             <div style="margin: 1ex 0 0 1ex">
+            <j:set var="targetBranchBuild" value="${result.getLinkToBuildThatWasUsedForComparison()}" />
+            <j:if test="${targetBranchBuild != null}">
+                <div class="changeRequestInformation">
+                    <j:set var="coverageDiff" value="${result.getChangeRequestCoverageDiffWithTargetBranch()}" />
+                    <j:choose>
+                        <j:when test="${coverageDiff gt 0}">
+                            <p>
+                                Code coverage increased in comparison with the <a href="${rootURL}/${targetBranchBuild}">target branch build</a>:
+                                <span style="color: green"> +${coverageDiff}%</span>
+                            </p>
+                        </j:when>
+                        <j:when test="${coverageDiff lt 0}">
+                            <p>
+                                Code coverage decreased in comparison with the <a href="${rootURL}/${targetBranchBuild}">target branch build</a>:
+                                <span style="color: red"> ${coverageDiff}%</span>
+                            </p>
+                        </j:when>
+                        <j:otherwise>
+                            <p>Code coverage hasn't changed in comparison with the <a href="${rootURL}/${targetBranchBuild}">target branch build</a></p>
+                        </j:otherwise>
+                    </j:choose>
+                </div>
+            </j:if>
             <j:forEach var="element" items="${result.elements}">
                 <b>${element.name}</b>:
                 ${result.getCoverage(element).percentage}%

--- a/src/main/resources/io/jenkins/plugins/coverage/CoverageProjectAction/floatingBox.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/CoverageProjectAction/floatingBox.jelly
@@ -10,6 +10,29 @@
             <div class="test-trend-caption">
                 ${%Code Coverage}
             </div>
+            <j:set var="targetBranchBuild" value="${lastResult.getLinkToBuildThatWasUsedForComparison()}" />
+            <j:if test="${targetBranchBuild != null}">
+                <div class="changeRequestInformation" style="width:600px; height:100%; text-align:center;">
+                    <j:set var="coverageDiff" value="${lastResult.getChangeRequestCoverageDiffWithTargetBranch()}" />
+                    <j:choose>
+                        <j:when test="${coverageDiff gt 0}">
+                            <p>
+                                Code coverage increased in comparison with the <a href="${rootURL}/${targetBranchBuild}">target branch build</a>:
+                                <span style="color: green"> +${coverageDiff}%</span>
+                            </p>
+                        </j:when>
+                        <j:when test="${coverageDiff lt 0}">
+                            <p>
+                                Code coverage decreased in comparison with the <a href="${rootURL}/${targetBranchBuild}">target branch build</a>:
+                                <span style="color: red"> ${coverageDiff}%</span>
+                            </p>
+                        </j:when>
+                        <j:otherwise>
+                            <p>Code coverage hasn't changed in comparison with the <a href="${rootURL}/${targetBranchBuild}">target branch build</a></p>
+                        </j:otherwise>
+                    </j:choose>
+                </div>
+            </j:if>
             <div id="summaryChart" style="width:600px;height:100%;">
             </div>
             <script>

--- a/src/main/resources/io/jenkins/plugins/coverage/CoveragePublisher/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/CoveragePublisher/config.jelly
@@ -19,6 +19,9 @@
             <div>
                 <f:checkbox field="failNoReports" title="Failed if No Reports Found"/>
             </div>
+            <div>
+                <f:checkbox field="calculateDiffForChangeRequests" title="If it is a change request build, calculate code coverage diff with a target branch build"/>
+            </div>
             <br/>
         </f:entry>
         <f:entry title="${%Global Thresholds}">

--- a/src/main/resources/io/jenkins/plugins/coverage/targets/CoverageResult/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/targets/CoverageResult/index.jelly
@@ -8,6 +8,29 @@
         <st:include it="${it.owner}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>${%Code Coverage}</h1>
+            <j:set var="targetBranchBuild" value="${it.getLinkToBuildThatWasUsedForComparison()}" />
+            <j:if test="${targetBranchBuild != null}">
+                <div class="changeRequestInformation" style="width:800px;height:100%;">
+                    <j:set var="coverageDiff" value="${it.getChangeRequestCoverageDiffWithTargetBranch()}" />
+                    <j:choose>
+                        <j:when test="${coverageDiff gt 0}">
+                            <h3>
+                                Code coverage increased in comparison with the <a href="${rootURL}/${targetBranchBuild}">target branch build</a>:
+                                <span style="color: green"> +${coverageDiff}%</span>
+                            </h3>
+                        </j:when>
+                        <j:when test="${coverageDiff lt 0}">
+                            <h3>
+                                Code coverage decreased in comparison with the <a href="${rootURL}/${targetBranchBuild}">target branch build</a>:
+                                <span style="color: red"> ${coverageDiff}%</span>
+                            </h3>
+                        </j:when>
+                        <j:otherwise>
+                            <h3>Code coverage hasn't changed in comparison with the <a href="${rootURL}/${targetBranchBuild}">target branch build</a></h3>
+                        </j:otherwise>
+                    </j:choose>
+                </div>
+            </j:if>
             <j:forEach var="parent" items="${it.parents}">
                 <a href="${it.relativeUrl(parent)}">${parent.xmlTransform(parent.name)}</a>
                 &gt;


### PR DESCRIPTION
It would be very convenient to see the code coverage diff right in Jenkins. If our
build is going for a multibranch change request job  - we take the
target branch commit that is used for our change request build. Then, we search through the
last fixed amount of builds the build that was built for this target branch commit. If
we find it - we check if it has line code coverage information. In case it has it -  we calculate diff between the current code coverage and this target branch build coverage.

Examples:
Increased code coverage:
![image](https://user-images.githubusercontent.com/19176095/57450419-1c175580-7267-11e9-8aeb-50b8ea60b617.png)


Decreased code coverage:
![image](https://user-images.githubusercontent.com/19176095/57450449-29ccdb00-7267-11e9-89f8-6f4cbc6300b5.png)

No changes:
![image](https://user-images.githubusercontent.com/19176095/57450463-2f2a2580-7267-11e9-89a8-38b882d6cad9.png)

Thank you.

