### PR TITLE
D coverage added

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/adapter/DListingReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/DListingReportAdapter.java
@@ -1,0 +1,195 @@
+package io.jenkins.plugins.coverage.adapter;
+
+import com.google.common.collect.Lists;
+import hudson.Extension;
+import io.jenkins.plugins.coverage.adapter.parser.CoverageParser;
+import io.jenkins.plugins.coverage.exception.CoverageException;
+import io.jenkins.plugins.coverage.targets.CoverageElement;
+import io.jenkins.plugins.coverage.targets.CoverageResult;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import javax.annotation.Nonnull;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.File;
+import java.util.List;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DListingReportAdapter extends CoverageReportAdapter {
+
+    private static final String UNCOVERED = "0000000";
+    private static final String NON_EXECUTABLE_CODE = "";
+
+    @DataBoundConstructor
+    public DListingReportAdapter(String path) {
+
+        super(path == null || path.equals("") ? "*.lst" : path);
+        setMergeToOneReport(true);
+    }
+
+    @Override
+    public Document convert(File source) throws CoverageException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (ParserConfigurationException e) {
+            e.printStackTrace();
+        }
+
+        factory.setNamespaceAware(true);
+        DocumentBuilder builder;
+        try {
+            builder = factory.newDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            throw new CoverageException(e);
+        }
+
+        Document document = builder.newDocument();
+        Element rootElement = document.createElement("report");
+        rootElement.setAttribute("name", "D Listing Coverage");
+        document.appendChild(rootElement);
+
+        Element fileElement = document.createElement("file");
+
+        try (BufferedReader br = Files.newBufferedReader(Paths.get(source.getPath()))) {
+            List<String> list = br.lines().collect(Collectors.toList());
+
+            if (list.size() == 0) {
+                return document;
+            }
+
+            String lastLine = list.get(list.size() - 1);
+            String moduleFileName = extractModuleFileName(lastLine);
+
+            if (moduleFileName == null) {
+                return document;
+            }
+
+            fileElement.setAttribute("name", moduleFileName);
+
+            int i = 0;
+            for (String line : list) {
+                String[] parts = line.split("\\|");
+                if (parts.length > 1) {
+                    String lineStatistic = parts[0].trim();
+
+                    if (!lineStatistic.equals(NON_EXECUTABLE_CODE)) {
+                        Element lineElement = document.createElement("line");
+                        lineElement.setAttribute("number", Integer.toString(i + 1));
+
+                        String hits = (lineStatistic.equals(UNCOVERED)) ? "0" : lineStatistic.trim();
+                        lineElement.setAttribute("hits", hits);
+                        fileElement.appendChild(lineElement);
+                    }
+                }
+                i++;
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        rootElement.appendChild(fileElement);
+        return document;
+    }
+
+    private String extractModuleFileName(String line) {
+        Pattern patternIsCovered = Pattern.compile("(.*) is \\d+% covered");
+        Pattern patternErrorIsCovered = Pattern.compile("Error: (.*) is \\d+% covered");
+        Pattern patternHasNoCode = Pattern.compile("(.*) has no code");
+
+        Matcher matcher = patternErrorIsCovered.matcher(line);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        matcher = patternHasNoCode.matcher(line);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        matcher = patternIsCovered.matcher(line);
+
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+
+        return null;
+    }
+
+    @Override
+    public CoverageResult parseToResult(Document document, String reportName) throws CoverageException {
+        return new DListingCoverageParser(reportName).parse(document);
+    }
+
+    @Symbol(value = {"dListingAdapter", "dListing"})
+    @Extension
+    public static final class DListingReportAdapterDescriptor extends CoverageReportAdapterDescriptor<CoverageReportAdapter> {
+
+        public DListingReportAdapterDescriptor() {
+            super(DListingReportAdapter.class);
+        }
+
+        @Override
+        public List<CoverageElement> getCoverageElements() {
+            return Lists.newArrayList(new CoverageElement("File", 0));
+        }
+
+        @Override
+        public String getCoverageElementType() {
+            return CoverageElement.COVERAGE_ELEMENT_TYPE_D;
+        }
+
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return Messages.DListingReportAdapter_displayName();
+        }
+    }
+
+    public static final class DListingCoverageParser extends CoverageParser {
+
+        public DListingCoverageParser(String reportName) {
+            super(reportName);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected CoverageResult processElement(Element current, CoverageResult parentResult) {
+            CoverageResult result = null;
+
+            switch (current.getTagName()) {
+                case "report":
+                    result = new CoverageResult(CoverageElement.REPORT, null,
+                            getAttribute(current, "name", "") + ": " + getReportName());
+                    break;
+                case "file":
+                    result = new CoverageResult(CoverageElement.get("File"), parentResult,
+                            getAttribute(current, "name", ""));
+                    result.setRelativeSourcePath(getAttribute(current, "name", null));
+                    break;
+                case "line":
+                    processLine(current, parentResult);
+                    break;
+                default:
+                    break;
+            }
+            return result;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageElement.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageElement.java
@@ -17,6 +17,7 @@ public class CoverageElement implements Comparable<CoverageElement>, Serializabl
     public final static String COVERAGE_ELEMENT_TYPE_NONE = "None";
     public final static String COVERAGE_ELEMENT_TYPE_JAVA = "Java";
     public final static String COVERAGE_ELEMENT_TYPE_JAVASCRIPT = "JavaScript";
+    public final static String COVERAGE_ELEMENT_TYPE_D = "D";
 
     private final String name;
     private final int order;

--- a/src/main/resources/io/jenkins/plugins/coverage/adapter/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/coverage/adapter/Messages.properties
@@ -1,3 +1,4 @@
 CoberturaReportAdapter.displayName=Cobertura
 JacocoReportAdapter.displayName=Jacoco
 IstanbulCoberturaReportAdapter.displayName=Istanbul (Cobertura reporter)
+DListingReportAdapter.displayName=D Listing


### PR DESCRIPTION
While setting default path in constructor seems to work,
setMergeToOneReport seems to have no effect.
User needs to tick checkbox manually to have a reasonable output.

```
public DListingReportAdapter(String path) {

        super(path == null || path.equals("") ? "*.lst" : path);
        setMergeToOneReport(true);
    }
```

A lst file looks like this
```
       |module p.client.base.http;
       |
       |import std.net.curl;
       |import std.string : toLower, join, split, startsWith, representation, strip, indexOf;
       |import std.range : chunks;
       |import std.algorithm : map, countUntil;
       |import std.uri : encodeComponent;
       |
       |import p.client.base.filesystem;
       |
       |enum HttpStatusCode
       |{
       |    ok = 200,
       |    noContent = 204,
       |    badRequest = 400,
       |    unauthorized = 401,
       |    forbidden = 403,
       |    notFound = 404,
       |    conflict = 409,
       |    internalServerError = 500,
       |    serviceUnavailable = 503,
       |    gatewayTimeout = 504
       |}
       |
       |enum HttpEncoding
       |{
       |    gzip = "gzip"
       |}
       |
       |enum HttpHeader
       |{
       |    authorization = "Authorization",
       |    contentType = "Content-Type",
       |    contentEncoding = "Content-Encoding",
       |    setCookie = "Set-Cookie",
       |    cookie = "Cookie",
       |    cacheControl = "Cache-Control",
       |    lastModified = "Last-Modified"
       |}
       |
       |alias HttpMethod = HTTP.Method;
       |
       |struct KeyValues(bool caseSensitive)
       |{
       |    private string[][string] _data;
       |
       |    @property string[] keys()
       |    {
     11|        return _data.keys;
       |    }
       |
      3|    this(string key, string value)
       |    {
      3|        add(key, value);
       |    }
       |
      1|    this(string[string] keyValues)
       |    {
      5|        foreach (t; keyValues.byKeyValue)
       |        {
      1|            add(t.key, t.value);
       |        }
       |    }
       |
      3|    this(KeyValues keyValues)
       |    {
      9|        foreach (key; keyValues.keys)
       |        {
0000000|            add(key, keyValues.getValues(key));
       |        }
       |    }
       |
       |    bool hasKey(string key)
       |    {
       |        static if (caseSensitive)
      8|            return (key in _data) !is null;
       |        else
     12|            return (key.toLower in _data) !is null;
       |    }
       |
       |    void add(string key, string value)
       |    {
       |        static if (caseSensitive)
      9|            _data[key] ~= value;
       |        else
     45|            _data[key.toLower] ~= value;
       |    }
       |
       |    void add(string key, string[] values)
       |    {
     45|        foreach (value; values)
      8|            add(key, value);
       |    }
       |
       |    string getValue(string key)
       |    {
0000000|        return getValues(key).join(", ");
       |    }
       |
       |    string[] getValues(string key)
       |    {
     14|        assert(hasKey(key));
       |        static if (caseSensitive)
      8|            return _data[key];
       |        else
      6|            return _data[key.toLower];
       |    }
       |}
       |
       |alias Headers = KeyValues!false;
       |alias Parameters = KeyValues!true;
       |
       |string parameterListToQuery(Parameters parameters)
       |{
     16|    return "?" ~ parameters.keys.map!(key => parameters.getValues(key)
      9|            .map!(value => key ~ "=" ~ encodeComponent(value)).join("&")).join("&");
       |}
       |
       |struct Request
       |{
       |    HttpMethod method = HttpMethod.get;
       |    string url;
       |    string username;
       |    string password;
       |    Headers headers;
       |    ubyte[] content;
       |    bool skipSslValidation;
       |
       |    @property bool isHttps()
       |    {
0000000|        return url.toLower.startsWith("https");
       |    }
       |
       |    @property void contentText(string s)
       |    {
0000000|        content = s.representation.dup;
       |    }
       |}
       |
       |struct Response
       |{
       |    HttpMethod method;
       |    ushort statusCode;
       |    ubyte[] content;
       |    Headers headers;
       |
       |    package @property void contentText(string s)
       |    {
0000000|        content = s.representation.dup;
       |    }
       |
       |    @property string contentText()
       |    {
      7|        return cast(string) content;
       |    }
       |}
       |
       |void addBearerAuthorization(ref Request request, string bearerToken)
       |{
      9|    request.headers.add(HttpHeader.authorization, "Bearer " ~ bearerToken);
       |}
       |
       |bool isHttpStatusCodeSuccess(ushort statusCode)
       |{
     13|    switch (statusCode) with (HttpStatusCode)
       |    {
     12|        case ok:
     12|            case noContent:
     12|            return true;
      1|        default:
      1|            return false;
       |    }
       |}
       |
       |string getXWwwFormUrlEncoded(string[] a...)
       |{
0000000|    assert(a.length % 2 == 0);
0000000|    return a.chunks(2).map!(c => c[0] ~ "=" ~ (c[1].encodeComponent)).join("&");
       |}
       |
       |class MultipartFormDataEncoder
       |{
       |    private struct TextPart
       |    {
       |        string name;
       |        string value;
       |    }
       |
       |    private struct FilePart
       |    {
       |        string name;
       |        string filePath;
       |    }
       |
       |    private string _boundary;
       |    private TextPart[] _textParts;
       |    private FilePart[] _fileParts;
       |    private IfFileSystem _fileSystem;
       |
       |    @property string boundary()
       |    {
      5|        return _boundary;
       |    }
       |
      5|    this(IfFileSystem fileSystem)
       |    {
      5|        _fileSystem = fileSystem;
      5|        _boundary = generateBoundary();
       |    }
       |
       |    void addText(string name, string value)
       |    {
      1|        _textParts ~= TextPart(name, value);
       |    }
       |
       |    void addFile(string fileName, string filePath)
       |    {
      4|        _fileParts ~= FilePart(fileName, filePath);
       |    }
       |
       |    string buildBody()
       |    {
       |        import std.array : appender;
       |
      5|        auto w = appender!string;
      5|        w.reserve(calculateBodySize());
       |
     18|        foreach (textPart; _textParts)
      1|            w.put(getTextPartHeader(textPart) ~ textPart.value ~ "\r\n");
       |
     27|        foreach (filePart; _fileParts)
       |        {
      4|            w.put(getFilePartHeader(filePart));
      4|            w.put(cast(char[]) _fileSystem.readBinaryFile(filePart.filePath));
      4|            w.put("\r\n");
       |        }
       |
      5|        w.put(getBodySuffix());
      5|        return w.data;
       |    }
       |
       |    private string getTextPartHeader(TextPart textPart)
       |    {
      2|        return "--" ~ _boundary ~ "\r\n" ~ `Content-Disposition: form-data; name="`
       |            ~ textPart.name ~ `"` ~ "\r\n" ~ "\r\n";
       |    }
       |
       |    private string getFilePartHeader(FilePart filePart)
       |    {
       |        import std.path : baseName;
       |
      8|        return "--" ~ _boundary ~ "\r\n" ~ `Content-Disposition: form-data; name="`
       |            ~ filePart.name ~ `"; filename="` ~ filePart.filePath.baseName ~ `"` ~ "\r\n"
       |            ~ "Content-Type: application/zip" ~ "\r\n"
       |            ~ "Content-Transfer-Encoding: binary" ~ "\r\n" ~ "\r\n";
       |    }
       |
       |    private string getBodySuffix()
       |    {
     10|        return "--" ~ _boundary ~ "--";
       |    }
       |
       |    size_t calculateBodySize()
       |    {
      5|        size_t size;
       |
     18|        foreach (textPart; _textParts)
      1|            size += (getTextPartHeader(textPart) ~ textPart.value ~ "\r\n").length;
       |
     27|        foreach (filePart; _fileParts)
       |        {
      4|            size_t filePartSize = _fileSystem.readFileSize(filePart.filePath);
      4|            size += (getFilePartHeader(filePart) ~ "\r\n").length + filePartSize;
       |        }
       |
      5|        size += getBodySuffix().length;
      5|        return size;
       |    }
       |
       |    private string generateBoundary()
       |    {
       |        import std.uuid : randomUUID;
       |
      5|        return randomUUID.toString();
       |    }
       |}
       |
       |class MultipartFormDataDecoder
       |{
       |    struct Part
       |    {
       |        string name;
       |        string fileName;
       |        ubyte[] value;
       |        bool isFile;
       |
       |        @property string valueText()
       |        {
      1|            return cast(string) value;
       |        }
       |    }
       |
       |    private string _boundary;
       |    private Part[] _parts;
       |
       |    @property Part[] parts()
       |    {
      4|        return _parts;
       |    }
       |
      2|    this(string boundary, string content)
       |    {
      2|        _boundary = boundary;
      2|        _parts = decode(content);
       |    }
       |
       |    private Part[] decode(string content)
       |    {
      2|        string[] lines = content.split("\r\n");
      2|        ptrdiff_t startLine = -1;
       |
      2|        auto getPart = (string[] partLines) {
       |            enum contentDisposition = "Content-Disposition: form-data;";
      4|            assert(partLines.length > 0 && partLines[0].startsWith(contentDisposition));
      2|            string dispAttrs = partLines[0][contentDisposition.length .. $].strip;
      2|            Part part;
       |
      2|            assert(dispAttrs.startsWith(`name="`));
      2|            auto nameEndPos = dispAttrs.indexOf(`"`, 6);
      2|            part.name = dispAttrs[6 .. nameEndPos];
       |
      2|            auto filenamePos = dispAttrs.indexOf(`filename="`);
      2|            if (filenamePos > -1)
       |            {
      1|                part.fileName = dispAttrs[filenamePos + 10 .. $ - 1];
      1|                part.isFile = true;
       |            }
       |
      2|            auto valueSepIndex = partLines.countUntil([""]);
      2|            part.value = (partLines[valueSepIndex + 1 .. $].join("\r\n")).representation.dup;
      2|            return part;
       |        };
       |
     54|        foreach (i, line; lines)
       |        {
     12|            if (line == "--" ~ _boundary)
       |            {
      2|                if (startLine > -1)
       |                {
0000000|                    _parts ~= getPart(lines[startLine + 1 .. i]);
       |                }
       |
      2|                startLine = i;
       |            }
     10|            else if (line == "--" ~ _boundary ~ "--")
       |            {
      2|                _parts ~= getPart(lines[startLine + 1 .. i]);
       |            }
       |        }
       |
      2|        return _parts;
       |    }
       |}
source/p/client/base/http.d is 91% covered
````