### PR TITLE
Change code coverage trend to use float format for coverage percentage

### DIFF
--- a/src/main/webapp/scripts/custom-chart.js
+++ b/src/main/webapp/scripts/custom-chart.js
@@ -374,7 +374,7 @@ var CoverageChartGenerator = function () {
                         data: []
                     }
                 }
-                series[metricIndex].data.push(ratio.percentage);
+                series[metricIndex].data.push(ratio.percentageFloat);
 
             });
 


### PR DESCRIPTION
Hi.

In large projects you have a lot of code lines and a lot of tests for
them. So, you may even delete whole tests and your code coverage won't
decrease if you track it in integer. It's more convenient if your
code coverage is shown in float so you can easily detect any code
coverage change between builds using the trend between builds that
Code Coverage Api plugin provides.

![image](https://user-images.githubusercontent.com/19176095/62245099-73057480-b3e9-11e9-8d86-ef5b466fb0bc.png)

Thank you.