### PR TITLE
Fix overlapping in case a coverage result has some really long name

### DIFF
--- a/src/main/webapp/scripts/custom-chart.js
+++ b/src/main/webapp/scripts/custom-chart.js
@@ -79,7 +79,8 @@ var CoverageChartGenerator = function () {
             },
             legend: {
                 data: ['Covered', 'Missed'],
-                right: 10
+                right: 10,
+                top: 25
             },
             grid: {
                 left: '3%',


### PR DESCRIPTION
Hi.

In case if your code coverage result has some long name It may overlap with the chart legend.

Before:
![image](https://user-images.githubusercontent.com/19176095/64945755-f126b900-d879-11e9-8e48-2439fb47a45a.png)

After:
![image](https://user-images.githubusercontent.com/19176095/64945788-07347980-d87a-11e9-980b-37191bde4fba.png)


What do you think about this?
Thank you.

