### PR TITLE
Avoid thread leak by copying files synchronously

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
+++ b/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
@@ -32,6 +32,7 @@ import io.jenkins.plugins.coverage.BuildUtils;
 import io.jenkins.plugins.coverage.exception.CoverageException;
 import io.jenkins.plugins.coverage.targets.CoveragePaint;
 import jenkins.MasterToSlaveFileCallable;
+import jenkins.util.Timer;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.jenkinsci.Symbol;
@@ -41,8 +42,6 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class DefaultSourceFileResolver extends SourceFileResolver {
@@ -80,11 +79,10 @@ public class DefaultSourceFileResolver extends SourceFileResolver {
 
         listener.getLogger().printf("%d source files need to be copied%n", paints.size());
 
-        ExecutorService service = Executors.newFixedThreadPool(5);
         // wait until all tasks completed
         CountDownLatch latch = new CountDownLatch(paints.entrySet().size());
 
-        paints.forEach((sourceFilePath, paint) -> service.submit(() -> {
+        paints.forEach((sourceFilePath, paint) -> Timer.get().submit(() -> {
             try {
                 FilePath[] possibleFiles;
                 try {

--- a/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
+++ b/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
@@ -32,7 +32,6 @@ import io.jenkins.plugins.coverage.BuildUtils;
 import io.jenkins.plugins.coverage.exception.CoverageException;
 import io.jenkins.plugins.coverage.targets.CoveragePaint;
 import jenkins.MasterToSlaveFileCallable;
-import jenkins.util.Timer;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.jenkinsci.Symbol;
@@ -41,8 +40,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 public class DefaultSourceFileResolver extends SourceFileResolver {
 
@@ -79,58 +76,42 @@ public class DefaultSourceFileResolver extends SourceFileResolver {
 
         listener.getLogger().printf("%d source files need to be copied%n", paints.size());
 
-        // wait until all tasks completed
-        CountDownLatch latch = new CountDownLatch(paints.entrySet().size());
-
-        paints.forEach((sourceFilePath, paint) -> Timer.get().submit(() -> {
+        paints.forEach((sourceFilePath, paint) -> {
+            FilePath[] possibleFiles;
             try {
-                FilePath[] possibleFiles;
+                if (getPossiblePaths() != null && getPossiblePaths().size() > 0) {
+                    possibleFiles = workspace.act(new FindSourceFileCallable(sourceFilePath, getPossiblePaths()));
+                } else {
+                    possibleFiles = workspace.act(new FindSourceFileCallable(sourceFilePath));
+                }
+            } catch (IOException | InterruptedException e) {
+                listener.getLogger().println(ExceptionUtils.getFullStackTrace(e));
+                return;
+            }
+            if (possibleFiles != null && possibleFiles.length > 0) {
+                FilePath source = possibleFiles[0];
+                FilePath copiedSource = new FilePath(new File(runRootDir, DEFAULT_SOURCE_CODE_STORE_DIRECTORY + sourceFilePath + "_copied"));
                 try {
-                    if (getPossiblePaths() != null && getPossiblePaths().size() > 0) {
-                        possibleFiles = workspace.act(new FindSourceFileCallable(sourceFilePath, getPossiblePaths()));
-                    } else {
-                        possibleFiles = workspace.act(new FindSourceFileCallable(sourceFilePath));
-                    }
+                    source.copyTo(copiedSource);
                 } catch (IOException | InterruptedException e) {
                     listener.getLogger().println(ExceptionUtils.getFullStackTrace(e));
                     return;
                 }
-                if (possibleFiles != null && possibleFiles.length > 0) {
-                    FilePath source = possibleFiles[0];
-                    FilePath copiedSource = new FilePath(new File(runRootDir, DEFAULT_SOURCE_CODE_STORE_DIRECTORY + sourceFilePath + "_copied"));
-                    try {
-                        source.copyTo(copiedSource);
-                    } catch (IOException | InterruptedException e) {
-                        listener.getLogger().println(ExceptionUtils.getFullStackTrace(e));
-                        return;
-                    }
 
-                    FilePath buildDirSourceFile = new FilePath(new File(runRootDir, DEFAULT_SOURCE_CODE_STORE_DIRECTORY + sourceFilePath));
+                FilePath buildDirSourceFile = new FilePath(new File(runRootDir, DEFAULT_SOURCE_CODE_STORE_DIRECTORY + sourceFilePath));
 
-                    try {
-                        paintSourceCode(copiedSource, paint, buildDirSourceFile);
-                    } catch (CoverageException e) {
-                        listener.getLogger().println(ExceptionUtils.getFullStackTrace(e));
-                    }
-
-                    deleteFilePathQuietly(copiedSource);
-                } else {
-                    listener.getLogger().printf("Cannot found source file for %s%n", sourceFilePath);
+                try {
+                    paintSourceCode(copiedSource, paint, buildDirSourceFile);
+                } catch (CoverageException e) {
+                    listener.getLogger().println(ExceptionUtils.getFullStackTrace(e));
                 }
-            } finally {
-                // ensure latch will count down
-                latch.countDown();
+
+                deleteFilePathQuietly(copiedSource);
+            } else {
+                listener.getLogger().printf("Cannot found source file for %s%n", sourceFilePath);
             }
-        }));
 
-
-        try {
-            //TODO make this configurable
-            latch.await(1, TimeUnit.HOURS);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-            throw new IOException("Unable to copy source files", e);
-        }
+        });
     }
 
 


### PR DESCRIPTION
We see unbounded thread growth with the following stack trace:

```
java.lang.Throwable: created pool #47
at java.util.concurrent.Executors$DefaultThreadFactory.<init>(Executors.java:610)
at java.util.concurrent.Executors.defaultThreadFactory(Executors.java:353)
at java.util.concurrent.ThreadPoolExecutor.<init>(ThreadPoolExecutor.java:1203)
at java.util.concurrent.Executors.newFixedThreadPool(Executors.java:89)
at io.jenkins.plugins.coverage.source.DefaultSourceFileResolver.resolveSourceFiles(DefaultSourceFileResolver.java:83)
at io.jenkins.plugins.coverage.CoverageProcessor.performCoverageReport(CoverageProcessor.java:115)
at io.jenkins.plugins.coverage.CoveragePublisher.perform(CoveragePublisher.java:94)
at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:80)
at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:67)
at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
```

Replicates what @jglick  did in jenkinsci/extreme-notification-plugin#8