### PR TITLE
When calculating link to last coverage data consider both SUCCESS or UNSTABLE

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProjectAction.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProjectAction.java
@@ -53,7 +53,7 @@ public class CoverageProjectAction extends Actionable implements ProminentProjec
      */
     public CoverageAction getLastResult() {
         for (Run<?, ?> b = run.getParent().getLastSuccessfulBuild(); b != null; b = BuildUtils.getPreviousNotFailedCompletedBuild(b)) {
-            if (b.getResult() == Result.FAILURE || (b.getResult() != Result.SUCCESS))
+            if (!((b.getResult() == Result.SUCCESS) || (b.getResult() == Result.UNSTABLE)))
                 continue;
             CoverageAction r = b.getAction(CoverageAction.class);
             if (r != null)

--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProjectAction.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProjectAction.java
@@ -69,7 +69,7 @@ public class CoverageProjectAction extends Actionable implements ProminentProjec
      */
     public Integer getLastResultBuild() {
         for (Run<?, ?> b = run.getParent().getLastSuccessfulBuild(); b != null; b = BuildUtils.getPreviousNotFailedCompletedBuild(b)) {
-            if (b.getResult() == Result.FAILURE || (b.getResult() != Result.SUCCESS))
+            if (!((b.getResult() == Result.SUCCESS) || (b.getResult() == Result.UNSTABLE)))
                 continue;
             CoverageAction r = b.getAction(CoverageAction.class);
             if (r != null)

--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProjectAction.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProjectAction.java
@@ -53,7 +53,7 @@ public class CoverageProjectAction extends Actionable implements ProminentProjec
      */
     public CoverageAction getLastResult() {
         for (Run<?, ?> b = run.getParent().getLastSuccessfulBuild(); b != null; b = BuildUtils.getPreviousNotFailedCompletedBuild(b)) {
-            if (!((b.getResult() == Result.SUCCESS) || (b.getResult() == Result.UNSTABLE)))
+            if (b.getResult() != Result.SUCCESS && b.getResult() != Result.UNSTABLE)
                 continue;
             CoverageAction r = b.getAction(CoverageAction.class);
             if (r != null)
@@ -69,7 +69,7 @@ public class CoverageProjectAction extends Actionable implements ProminentProjec
      */
     public Integer getLastResultBuild() {
         for (Run<?, ?> b = run.getParent().getLastSuccessfulBuild(); b != null; b = BuildUtils.getPreviousNotFailedCompletedBuild(b)) {
-            if (!((b.getResult() == Result.SUCCESS) || (b.getResult() == Result.UNSTABLE)))
+            if (b.getResult() != Result.SUCCESS && b.getResult() != Result.UNSTABLE)
                 continue;
             CoverageAction r = b.getAction(CoverageAction.class);
             if (r != null)


### PR DESCRIPTION

When calculating the link to last coverage data, which is the link from the left menu, the plugin would just consider builds that were SUCCESS. But the plugin itself can make a build UNSTABLE (ie. code coverage limits not reached) and that data will not be pointed therefore.

This PR just takes into account both SUCCESS and UNSTABLE results for the link.

To reproduce:
-) Set code coverage thresholds (unstableThreshold) to a value that your code is not reaching and execute the build.
-) Check the link from the left menu in "Coverage Report": this will not point to the just executed job. As an extreme if all are UNSTABLE then the menu action will fail.

Tested PR manually with success.