### PR TITLE
Fix small HTML tags errors in painted source code files

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
+++ b/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
@@ -159,12 +159,12 @@ public class DefaultSourceFileResolver extends SourceFileResolver {
                     } else {
                         output.write("<tr class=\"coverNone\">\n");
                     }
-                    output.write("<td class=\"line\"><a name='" + line + "'/>" + line + "</td>\n");
+                    output.write("<td class=\"line\"><a name='" + line + "'>" + line + "</a></td>\n");
                     output.write("<td class=\"hits\">" + hits + "</td>\n");
                 } else {
                     output.write("<tr class=\"noCover\">\n");
-                    output.write("<td class=\"line\"><a name='" + line + "'/>" + line + "</td>\n");
-                    output.write("<td class=\"hits\"/>\n");
+                    output.write("<td class=\"line\"><a name='" + line + "'>" + line + "</a></td>\n");
+                    output.write("<td class=\"hits\"></td>\n");
                 }
                 output.write("<td class=\"code\">"
                         + content.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "").replace("\r", "").replace(" ",

--- a/src/main/resources/io/jenkins/plugins/coverage/targets/CoverageResult/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/targets/CoverageResult/index.jelly
@@ -112,10 +112,7 @@
                                         <th colspan="3">${it.relativeSourcePath}</th>
                                     </tr>
                                 </thead>
-                                <pre>
-                                    <j:out value="${it.sourceFileContent}"/>
-                                </pre>
-
+                                <j:out value="${it.sourceFileContent}"/>
                             </table>
                         </div>
                     </j:when>


### PR DESCRIPTION
The HTML generated with painted source code has a bunch of errors with tags that may make the rendering bad on older browsers or may anyhow leave to the browser the freedom to rearrange the code.
Example from Firefox source code parsing:

![coverage-plugin-html](https://user-images.githubusercontent.com/19709142/69601355-2b4bce00-1014-11ea-9b89-3ac8fa519f62.png)

In the example you see that the closing of `<a>` is considered invalid (it is not a _void element_) and the `<td>` of hits is never closed. Also the whole table was inside a `<pre>` (preformatted) tag which doesn't make sense it being a table.

This PR fixes this little HTML quirks and makes the page more HTML5 compliant.