### PR TITLE
add additionalProperty to istanbul-cobertura-to-standard.xsl to keep …

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/adapter/IstanbulCoberturaReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/IstanbulCoberturaReportAdapter.java
@@ -6,6 +6,7 @@ import io.jenkins.plugins.coverage.adapter.parser.CoverageParser;
 import io.jenkins.plugins.coverage.exception.CoverageException;
 import io.jenkins.plugins.coverage.targets.CoverageElement;
 import io.jenkins.plugins.coverage.targets.CoverageResult;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.w3c.dom.Document;
@@ -111,6 +112,15 @@ public class IstanbulCoberturaReportAdapter extends XMLCoverageReportAdapter {
                     break;
                 case "line":
                     processLine(current, parentResult);
+                    break;
+                case "additionalProperty":
+                    String propertyName = getAttribute(current, "name", "");
+                    if (StringUtils.isEmpty(propertyName)) {
+                        break;
+                    }
+
+                    String propertyValue = getAttribute(current, "value", "");
+                    parentResult.addAdditionalProperty(propertyName, propertyValue);
                     break;
                 default:
                     break;

--- a/src/main/resources/io/jenkins/plugins/coverage/adapter/istanbul-cobertura-to-standard.xsl
+++ b/src/main/resources/io/jenkins/plugins/coverage/adapter/istanbul-cobertura-to-standard.xsl
@@ -6,9 +6,17 @@
         <report>
             <xsl:attribute name="name">istanbul</xsl:attribute>
             <xsl:apply-templates select="coverage/packages/package"/>
+            <xsl:apply-templates select="coverage/sources/source"/>
         </report>
     </xsl:template>
 
+    <xsl:template match="coverage/sources/source">
+        <additionalProperty name="source-file-path">
+            <xsl:attribute name="value">
+                <xsl:value-of select="text()"/>
+            </xsl:attribute>
+        </additionalProperty>
+    </xsl:template>
 
     <xsl:template match="coverage/packages/package">
         <directory>


### PR DESCRIPTION
I added additionalProperty support to `istanbul-cobertura-to-standard.xsl` according to [`cobertura-to-standard.xsl`](https://github.com/jenkinsci/cobertura-plugin/blob/master/src/main/resources/hudson/plugins/cobertura/adapter/cobertura-to-standard.xsl).
Also, I made corresponding changes to `IstanbulCoberturaReportAdapter` to enable it to handle additionalProperty.
After these two changes, the embeded istanbul-cobertura adapter can now find out where source file path is according to the coverage/sources/source property in coverage.xml (the report file for cobertura).