### PR TITLE
bug fix for display of methods like "<init>" 

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/adapter/IstanbulCoberturaReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/IstanbulCoberturaReportAdapter.java
@@ -6,6 +6,7 @@ import io.jenkins.plugins.coverage.adapter.parser.CoverageParser;
 import io.jenkins.plugins.coverage.exception.CoverageException;
 import io.jenkins.plugins.coverage.targets.CoverageElement;
 import io.jenkins.plugins.coverage.targets.CoverageResult;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.w3c.dom.Document;
@@ -111,6 +112,15 @@ public class IstanbulCoberturaReportAdapter extends XMLCoverageReportAdapter {
                     break;
                 case "line":
                     processLine(current, parentResult);
+                    break;
+                case "additionalProperty":
+                    String propertyName = getAttribute(current, "name", "");
+                    if (StringUtils.isEmpty(propertyName)) {
+                        break;
+                    }
+
+                    String propertyValue = getAttribute(current, "value", "");
+                    parentResult.addAdditionalProperty(propertyName, propertyValue);
                     break;
                 default:
                     break;

--- a/src/main/resources/io/jenkins/plugins/coverage/adapter/istanbul-cobertura-to-standard.xsl
+++ b/src/main/resources/io/jenkins/plugins/coverage/adapter/istanbul-cobertura-to-standard.xsl
@@ -6,9 +6,17 @@
         <report>
             <xsl:attribute name="name">istanbul</xsl:attribute>
             <xsl:apply-templates select="coverage/packages/package"/>
+            <xsl:apply-templates select="coverage/sources/source"/>
         </report>
     </xsl:template>
 
+    <xsl:template match="coverage/sources/source">
+        <additionalProperty name="source-file-path">
+            <xsl:attribute name="value">
+                <xsl:value-of select="text()"/>
+            </xsl:attribute>
+        </additionalProperty>
+    </xsl:template>
 
     <xsl:template match="coverage/packages/package">
         <directory>

--- a/src/main/webapp/scripts/custom-chart.js
+++ b/src/main/webapp/scripts/custom-chart.js
@@ -15,6 +15,13 @@ var CoverageChartGenerator = function () {
         return s;
     }
 
+    /**
+     * To display name like "&lt;init&gt;" or "&amp;lt;init&amp;gt;" as "<init>".
+     */
+    function transformXML(name) {
+        return name.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+    }
+
     this.generateSummaryChart = function (results, id, name, isTitleHasLink) {
 
         var summaryChartDiv = document.getElementById(id);
@@ -47,8 +54,15 @@ var CoverageChartGenerator = function () {
 
         var stackedBarOption = {
 
+            // Configuration like below won't lead to injection attack, because the text is displayed "as is".
+            // So the transformation is all right, and it does help displaying name like "&lt;init&gt;" or "&amp;lt;init&amp;gt;" as "<init>".
+            //
+            // title: {
+            //     text: "<script>alert(\"inject test\")</script>>"
+            // },
+
             title: {
-                text: name + (isTitleHasLink?' (click to see more details)':'')
+                text: transformXML(name) + (isTitleHasLink?' (click to see more details)':'')
             },
 
             toolbox: {


### PR DESCRIPTION
Before this change, this api plugin would display "&lt;init&gt;" method as "&amp;amp;lt;init&amp;amp;gt;" when showing coverage report for the method.

![escape](https://user-images.githubusercontent.com/29347603/72787663-51d06300-3c6b-11ea-86b7-08834c952c5f.png)

Generally, this bug occurs when the method name contains "&lt;" and/or "&gt;". Let's still take "&lt;init&gt;" for example, after the process of `io.jenkins.plugins.coverage.targets.CoverageResult#xmlTransform`, this name will be "&amp;lt;init&amp;gt;", then since the corresponding jelly file's `escape-by-default` property is true, the name will be further escaped to "&amp;amp;lt;init&amp;amp;gt;".

When displaying the method name, the text is displayed "as is", so escaping is not necessary. So this PR won't lead to XSS issues.

After this change, the display will work fine.

![escape-reverse](https://user-images.githubusercontent.com/29347603/72790124-f05ec300-3c6f-11ea-8fd5-c18e16da0115.png)

