### PR TITLE
JENKINS-60359: Use standard breadcrumbs

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -24,6 +24,7 @@ package io.jenkins.plugins.coverage.targets;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Item;
+import hudson.model.ModelObject;
 import hudson.model.Run;
 import hudson.util.ChartUtil;
 import hudson.util.TextFile;
@@ -56,7 +57,7 @@ import java.util.stream.Collectors;
  * @since 22-Aug-2007 18:47:10
  */
 @ExportedBean(defaultVisibility = 2)
-public class CoverageResult implements Serializable, Chartable {
+public class CoverageResult implements Serializable, Chartable, ModelObject {
 
     /**
      * Generated
@@ -692,6 +693,12 @@ public class CoverageResult implements Serializable, Chartable {
             }
         }
         return results;
+    }
+
+    // see https://issues.jenkins-ci.org/browse/JENKINS-60359
+    @Override
+    public String getDisplayName() {
+        return getName();
     }
 
 

--- a/src/main/resources/io/jenkins/plugins/coverage/targets/CoverageResult/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/targets/CoverageResult/index.jelly
@@ -31,10 +31,11 @@
                     </j:choose>
                 </div>
             </j:if>
-            <j:forEach var="parent" items="${it.parents}">
-                <a href="${it.relativeUrl(parent)}">${parent.xmlTransform(parent.name)}</a>
-                &gt;
-            </j:forEach>
+            <!-- See https://issues.jenkins-ci.org/browse/JENKINS-60359 -->
+            <!--<j:forEach var="parent" items="${it.parents}">-->
+            <!--    <a href="${it.relativeUrl(parent)}">${parent.xmlTransform(parent.name)}</a>-->
+            <!--    &gt;-->
+            <!--</j:forEach>-->
             <br/>
             <br/>
             <br/>


### PR DESCRIPTION
Before this pr, the plugin shows coverage reports like this:

![breadcrumb](https://user-images.githubusercontent.com/29347603/74925934-106cd800-5410-11ea-9804-4716b0867f89.png)

Now the issue is fixed!

![breadcrumb-fixed](https://user-images.githubusercontent.com/29347603/74928036-afdf9a00-5413-11ea-84fe-a710a4ed637b.PNG)
