### PR TITLE
Fix #150. Remove wars about source files with the same names

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
+++ b/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
@@ -122,7 +122,6 @@ public class DefaultSourceFileResolver extends SourceFileResolver {
                             FilePath::getName,
                             Function.identity(),
                             (path1, path2) -> {
-                                listener.getLogger().println("WARNING: Duplicate filename found: " + path1.getName());
                                 return path1;
                             }
                     ));


### PR DESCRIPTION
The Jacoco fix in 4081720909b brought new code that tries to find the
source file in case other ways didn't work. To do this it creates a
map of file names to look for. And it logs warnings in case of any
duplicates. Becase there may be a lot of them a log would quite apace,
we remove the warnings.