### PR TITLE
Also set a fail message if marking stage as unstable so that checks API correctly reports non-success

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -482,6 +482,7 @@ public class CoverageProcessor {
                 action.setFailMessage(String.format("Build failed because following metrics did not meet stability target: %s.", unstableThresholds.toString()));
                 throw new CoverageException(action.getFailMessage());
             } else {
+                action.setFailMessage(String.format("Build unstable because following metrics did not meet stability target: %s.", unstableThresholds.toString()));
                 run.setResult(Result.UNSTABLE);
             }
         }


### PR DESCRIPTION
Hopefully fixes #176 