### PR TITLE
Missing Cobertura source files due to hardcoded URI's in Cobertura xml files.

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
+++ b/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
@@ -39,10 +39,13 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import javax.annotation.Nonnull;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DefaultSourceFileResolver extends SourceFileResolver {
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Cobertura places a hardcoded URI within it's own xml files which causes find failures if the Jenkins' job is renamed or moved.  Current code attempts to find the files, but because each xml may have a different base URI, the current find doesn't necessarily create a correct path to the files.
Added code in branch does a regex search to find the file given a known subpath.  The added code attempts to find the missing piece of the URI.

I found this hardcoded URI has also caused issue for other projects that use Cobertura.  This patch is a bandaid to work around the issue until Cobertura itself works with relative paths.


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
