### PR TITLE
Ignore Doctype errors caused by Cobertura adding to top of xml files.

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/adapter/converter/DocumentConverter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/converter/DocumentConverter.java
@@ -23,7 +23,7 @@ public abstract class DocumentConverter<T> {
             factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
         } catch (ParserConfigurationException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fix for Issue: https://github.com/jenkinsci/code-coverage-api-plugin/issues/162

In our environment, we noticed that Cobertura files were failing consumption.  The error was traced to Cobertura itself adding a doctype to the top of it's files.  
From commit 0a43672:
"Per OWASP (https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxp-documentbuilderfactory-saxparserfactory-and-dom4j), not all four features need set at the same time.
If "disallow-doctype-decl" cannot be set to false, in this case because Cobertura sets the DOCTYPE, then at least "external-general-entities" should be set to false.
Both do not need to be set as "disallow-doctype-decl" is already a more secure setting, making setting "external-general-entities" worthless."

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->