### PR TITLE
Remove broken build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # code-coverage-api-plugin
 
-[![Build Status](https://ci.jenkins.io/job/Plugins/job/code-coverage-api-plugin/job/dev/badge/icon)](https://ci.jenkins.io/job/Plugins/job/code-coverage-api-plugin/job/dev/)
 [![Gitter](https://badges.gitter.im/jenkinsci/code-coverage-api-plugin.svg)](https://gitter.im/jenkinsci/code-coverage-api-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 
@@ -155,5 +154,3 @@ We provide a REST API to retrieve coverage data:
 - Trend result of last build: `…​/{buildNumber}/coverage/…​/last/trend/api/\{json|xml\}?depth={number}`
 
 Note: The larger the number, the deeper of coverage information can be retrieved.
-
-


### PR DESCRIPTION
Many plugins have stopped displaying separate status badges.

The GitHub repository "checkmark" shows the status in  the GitHub repository.

![image](https://user-images.githubusercontent.com/156685/113444704-a617bc80-93b1-11eb-9ae5-903d11251f00.png)

Documentation update, no need for changelog or for Jira issue.

## Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
