### PR TITLE
Extend delta coverage api

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/CoverageChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageChecksPublisher.java
@@ -99,9 +99,9 @@ class CoverageChecksPublisher {
 
         if (result.getCoverage(CoverageElement.LINE) != null) {
             float lineCoverage = result.getCoverage(CoverageElement.LINE).getPercentageFloat();
-            if (result.getLinkToBuildThatWasUsedForComparison() != null) {
+            if (result.getReferenceBuildUrl() != null) {
                 title.append(extractChecksTitle("Line", "target branch", lineCoverage,
-                        result.getChangeRequestCoverageDiffWithTargetBranch()));
+                        result.getLineCoverageDelta()));
             } else if (lastRatios.containsKey(CoverageElement.LINE)) {
                  title.append(extractChecksTitle("Line", "last successful build", lineCoverage,
                         lineCoverage - lastRatios.get(CoverageElement.LINE).getPercentageFloat()));
@@ -151,9 +151,9 @@ class CoverageChecksPublisher {
 
     private String extractComparedBuildsSummary(final CoverageResult result) {
         StringBuilder summary = new StringBuilder();
-        if (result.getLinkToBuildThatWasUsedForComparison() != null) {
+        if (result.getReferenceBuildUrl() != null) {
             summary.append("* ### [Target branch build](")
-                    .append(jenkinsFacade.getAbsoluteUrl(result.getLinkToBuildThatWasUsedForComparison()))
+                    .append(jenkinsFacade.getAbsoluteUrl(result.getReferenceBuildUrl()))
                     .append(")\n");
         }
 

--- a/src/main/java/io/jenkins/plugins/coverage/CoverageChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageChecksPublisher.java
@@ -101,7 +101,7 @@ class CoverageChecksPublisher {
             float lineCoverage = result.getCoverage(CoverageElement.LINE).getPercentageFloat();
             if (result.getReferenceBuildUrl() != null) {
                 title.append(extractChecksTitle("Line", "target branch", lineCoverage,
-                        result.getLineCoverageDelta()));
+                        result.getCoverageDelta(CoverageElement.LINE)));
             } else if (lastRatios.containsKey(CoverageElement.LINE)) {
                  title.append(extractChecksTitle("Line", "last successful build", lineCoverage,
                         lineCoverage - lastRatios.get(CoverageElement.LINE).getPercentageFloat()));

--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -210,9 +210,9 @@ public class CoverageProcessor {
     }
 
     private void failBuildIfChangeRequestDecreasedCoverage(CoverageResult coverageResult) throws CoverageException {
-        float coverageDiff = coverageResult.getLineCoverageDelta();
+        float coverageDiff = coverageResult.getCoverageDelta(CoverageElement.LINE);
         if (coverageDiff < 0) {
-            throw new CoverageException("Fail build because this change request decreases code coverage by " + coverageDiff);
+            throw new CoverageException("Fail build because this change request decreases line coverage by " + coverageDiff);
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 public class CoverageProcessor {
@@ -193,20 +194,23 @@ public class CoverageProcessor {
             return;
         }
 
-        // Calculate diff only for line coverage
-        Ratio changeRequestLinesCoverage = coverageReport.getCoverage(CoverageElement.LINE);
-        if (changeRequestLinesCoverage == null) {
-            return;
-        }
+        Map<CoverageElement, Float> deltaCoverage = new TreeMap<>();
+        targetBranchCoverageResult.getResults().forEach((coverageElement, referenceRatio) -> {
+            Ratio buildRatio = coverageReport.getCoverage(coverageElement);
 
-        float percentageDiff =
-                changeRequestLinesCoverage.getPercentageFloat() - referenceLineCoverage.getPercentageFloat();
-        coverageReport.setChangeRequestCoverageDiffWithTargetBranch(percentageDiff);
-        coverageReport.setLinkToBuildThatWasUsedForComparison(referenceBuild.getUrl());
+            if (buildRatio != null) {
+                float diff = buildRatio.getPercentageFloat() - referenceRatio.getPercentageFloat();
+                listener.getLogger().println(coverageElement.getName() + " coverage diff: " + diff + "%. Add to CoverageResult.");
+                deltaCoverage.put(coverageElement, diff);
+            }
+        });
+
+        coverageReport.setReferenceBuildUrl(buildToTakeCoverageFrom.getUrl());
+        coverageReport.setDeltaResults(deltaCoverage);
     }
 
     private void failBuildIfChangeRequestDecreasedCoverage(CoverageResult coverageResult) throws CoverageException {
-        float coverageDiff = coverageResult.getChangeRequestCoverageDiffWithTargetBranch();
+        float coverageDiff = coverageResult.getLineCoverageDelta();
         if (coverageDiff < 0) {
             throw new CoverageException("Fail build because this change request decreases code coverage by " + coverageDiff);
         }

--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -195,7 +195,7 @@ public class CoverageProcessor {
         }
 
         Map<CoverageElement, Float> deltaCoverage = new TreeMap<>();
-        targetBranchCoverageResult.getResults().forEach((coverageElement, referenceRatio) -> {
+        referenceCoverageResult.getResults().forEach((coverageElement, referenceRatio) -> {
             Ratio buildRatio = coverageReport.getCoverage(coverageElement);
 
             if (buildRatio != null) {
@@ -205,7 +205,7 @@ public class CoverageProcessor {
             }
         });
 
-        coverageReport.setReferenceBuildUrl(buildToTakeCoverageFrom.getUrl());
+        coverageReport.setReferenceBuildUrl(referenceBuild.getUrl());
         coverageReport.setDeltaResults(deltaCoverage);
     }
 

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -77,6 +77,7 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
     private String tag;
 
     private String referenceBuildUrl = null;
+    private float changeRequestCoverageDiffWithTargetBranch = 0;
 
     // these two pointers form a tree structure where edges are names.
     private CoverageResult parent;
@@ -87,7 +88,7 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
 
     private final Map<CoverageElement, Ratio> localResults = new TreeMap<>();
 
-    private Map<CoverageElement, Float> deltaResults = new TreeMap<>();
+    private final Map<CoverageElement, Float> deltaResults = new TreeMap<>();
 
     /**
      * Line-by-line coverage information. Computed lazily, since it's memory intensive.
@@ -236,6 +237,25 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
         return deltaResults.get(CoverageElement.LINE);
     }
 
+    /**
+     * Getter for property 'changeRequestCoverageDiffWithTargetBranch'.
+     *
+     * @return Value for property 'changeRequestCoverageDiffWithTargetBranch'.
+     * @deprecated use {@link #getLineCoverageDelta()} instead.
+     */
+    public float getChangeRequestCoverageDiffWithTargetBranch() {
+        return changeRequestCoverageDiffWithTargetBranch;
+    }
+
+    /**
+     * Setter for property 'changeRequestCoverageDiffWithTargetBranch'.
+     *
+     * @param changeRequestCoverageDiffWithTargetBranch Value to set for property 'changeRequestCoverageDiffWithTargetBranch'.
+     * @deprecated diff coverage is stored in {@link #deltaResults}.
+     */
+    public void setChangeRequestCoverageDiffWithTargetBranch(float changeRequestCoverageDiffWithTargetBranch) {
+        this.changeRequestCoverageDiffWithTargetBranch = changeRequestCoverageDiffWithTargetBranch;
+    }
 
     /**
      * Getter for property 'referenceBuildUrl'.
@@ -378,7 +398,8 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
      * @param deltaResults Value to set for property 'deltaResults'.
      */
     public void setDeltaResults(Map<CoverageElement, Float> deltaResults) {
-        this.deltaResults = deltaResults;
+        this.deltaResults.clear();
+        this.deltaResults.putAll(deltaResults);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -246,6 +246,7 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
      * @return Value for property 'changeRequestCoverageDiffWithTargetBranch'.
      * @deprecated use {@link #getCoverageDelta(CoverageElement)} instead.
      */
+    @Deprecated
     public float getChangeRequestCoverageDiffWithTargetBranch() {
         return changeRequestCoverageDiffWithTargetBranch;
     }
@@ -256,6 +257,7 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
      * @param changeRequestCoverageDiffWithTargetBranch Value to set for property 'changeRequestCoverageDiffWithTargetBranch'.
      * @deprecated diff coverage is stored in {@link #deltaResults}.
      */
+    @Deprecated
     public void setChangeRequestCoverageDiffWithTargetBranch(float changeRequestCoverageDiffWithTargetBranch) {
         this.changeRequestCoverageDiffWithTargetBranch = changeRequestCoverageDiffWithTargetBranch;
     }

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -21,7 +21,6 @@
  */
 package io.jenkins.plugins.coverage.targets;
 
-import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Item;
 import hudson.model.ModelObject;
@@ -77,11 +76,7 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
     private String name;
     private String tag;
 
-    /**
-     * Properties to store a change request coverage diff with the latest successful build from the target branch
-     */
-    private float changeRequestCoverageDiffWithTargetBranch = 0;
-    private String linkToBuildThatWasUsedForComparison = null;
+    private String referenceBuildUrl = null;
 
     // these two pointers form a tree structure where edges are names.
     private CoverageResult parent;
@@ -91,6 +86,8 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
     private final Map<CoverageElement, Ratio> aggregateResults = new TreeMap<>();
 
     private final Map<CoverageElement, Ratio> localResults = new TreeMap<>();
+
+    private Map<CoverageElement, Float> deltaResults = new TreeMap<>();
 
     /**
      * Line-by-line coverage information. Computed lazily, since it's memory intensive.
@@ -231,39 +228,31 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
     }
 
     /**
-     * Getter for property 'changeRequestCoverageDiffWithTargetBranch'.
+     * Getter for property 'lineCoverageDelta'.
      *
-     * @return Value for property 'changeRequestCoverageDiffWithTargetBranch'.
+     * @return Value for property 'lineCoverageDelta'.
      */
-    public float getChangeRequestCoverageDiffWithTargetBranch() {
-        return changeRequestCoverageDiffWithTargetBranch;
+    public float getLineCoverageDelta() {
+        return deltaResults.get(CoverageElement.LINE);
+    }
+
+
+    /**
+     * Getter for property 'referenceBuildUrl'.
+     *
+     * @return Value for property 'referenceBuildUrl'.
+     */
+    public String getReferenceBuildUrl() {
+        return referenceBuildUrl;
     }
 
     /**
-     * Setter for property 'changeRequestCoverageDiffWithTargetBranch'.
+     * Setter for property 'referenceBuildUrl'.
      *
-     * @param changeRequestCoverageDiffWithTargetBranch Value to set for property 'changeRequestCoverageDiffWithTargetBranch'.
+     * @param referenceBuildUrl Value to set for property 'referenceBuildUrl'.
      */
-    public void setChangeRequestCoverageDiffWithTargetBranch(float changeRequestCoverageDiffWithTargetBranch) {
-        this.changeRequestCoverageDiffWithTargetBranch = changeRequestCoverageDiffWithTargetBranch;
-    }
-
-    /**
-     * Getter for property 'linkToBuildThatWasUsedForComparison'.
-     *
-     * @return Value for property 'linkToBuildThatWasUsedForComparison'.
-     */
-    public String getLinkToBuildThatWasUsedForComparison() {
-        return linkToBuildThatWasUsedForComparison;
-    }
-
-    /**
-     * Setter for property 'linkToBuildThatWasUsedForComparison'.
-     *
-     * @param linkToBuildThatWasUsedForComparison Value to set for property 'linkToBuildThatWasUsedForComparison'.
-     */
-    public void setLinkToBuildThatWasUsedForComparison(String linkToBuildThatWasUsedForComparison) {
-        this.linkToBuildThatWasUsedForComparison = linkToBuildThatWasUsedForComparison;
+    public void setReferenceBuildUrl(String referenceBuildUrl) {
+        this.referenceBuildUrl = referenceBuildUrl;
     }
 
     /**
@@ -372,6 +361,24 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
      */
     public Map<CoverageElement, Ratio> getResults() {
         return Collections.unmodifiableMap(aggregateResults);
+    }
+
+    /**
+     * Getter for property 'deltaResults'.
+     *
+     * @return Value for property 'deltaResults'.
+     */
+    public Map<CoverageElement, Float> getDeltaResults() {
+        return Collections.unmodifiableMap(deltaResults);
+    }
+
+    /**
+     * Setter for property 'deltaResults'.
+     *
+     * @param deltaResults Value to set for property 'deltaResults'.
+     */
+    public void setDeltaResults(Map<CoverageElement, Float> deltaResults) {
+        this.deltaResults = deltaResults;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -229,19 +229,22 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
     }
 
     /**
-     * Getter for property 'lineCoverageDelta'.
+     * Get delta coverage from {@link #deltaResults} for a specific {@link CoverageElement}.
      *
-     * @return Value for property 'lineCoverageDelta'.
+     * @param element
+     *          the element to get the diff coverage for.
+     * @return
+     *          the diff coverage or 0, if diff coverage for element is not available.
      */
-    public float getLineCoverageDelta() {
-        return deltaResults.get(CoverageElement.LINE);
+    public float getCoverageDelta(CoverageElement element) {
+        return deltaResults.getOrDefault(element, 0.0F);
     }
 
     /**
      * Getter for property 'changeRequestCoverageDiffWithTargetBranch'.
      *
      * @return Value for property 'changeRequestCoverageDiffWithTargetBranch'.
-     * @deprecated use {@link #getLineCoverageDelta()} instead.
+     * @deprecated use {@link #getCoverageDelta(CoverageElement)} instead.
      */
     public float getChangeRequestCoverageDiffWithTargetBranch() {
         return changeRequestCoverageDiffWithTargetBranch;

--- a/src/main/resources/io/jenkins/plugins/coverage/CoverageAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/CoverageAction/summary.jelly
@@ -5,10 +5,10 @@
         <j:set var="result" value="${it.target}" />
         <j:if test="${result != null}">
             <div style="margin: 1ex 0 0 1ex">
-            <j:set var="targetBranchBuild" value="${result.getLinkToBuildThatWasUsedForComparison()}" />
+            <j:set var="targetBranchBuild" value="${result.getReferenceBuildUrl()}" />
             <j:if test="${targetBranchBuild != null}">
                 <div class="changeRequestInformation">
-                    <j:set var="coverageDiff" value="${result.getChangeRequestCoverageDiffWithTargetBranch()}" />
+                    <j:set var="coverageDiff" value="${result.getLineCoverageDelta()}" />
                     <j:choose>
                         <j:when test="${coverageDiff gt 0}">
                             <p>

--- a/src/main/resources/io/jenkins/plugins/coverage/CoverageProjectAction/floatingBox.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/CoverageProjectAction/floatingBox.jelly
@@ -10,10 +10,10 @@
             <div class="test-trend-caption">
                 ${%Code Coverage}
             </div>
-            <j:set var="targetBranchBuild" value="${lastResult.getLinkToBuildThatWasUsedForComparison()}" />
+            <j:set var="targetBranchBuild" value="${lastResult.getReferenceBuildUrl()}" />
             <j:if test="${targetBranchBuild != null}">
                 <div class="changeRequestInformation" style="width:500px; height:100%; text-align:center;">
-                    <j:set var="coverageDiff" value="${lastResult.getChangeRequestCoverageDiffWithTargetBranch()}" />
+                    <j:set var="coverageDiff" value="${lastResult.getLineCoverageDelta()}" />
                     <j:choose>
                         <j:when test="${coverageDiff gt 0}">
                             <p>

--- a/src/main/resources/io/jenkins/plugins/coverage/targets/CoverageResult/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/targets/CoverageResult/index.jelly
@@ -8,10 +8,10 @@
         <st:include it="${it.owner}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>${%Code Coverage}</h1>
-            <j:set var="targetBranchBuild" value="${it.getLinkToBuildThatWasUsedForComparison()}" />
+            <j:set var="targetBranchBuild" value="${it.getReferenceBuildUrl()}" />
             <j:if test="${targetBranchBuild != null}">
                 <div class="changeRequestInformation" style="width:800px;height:100%;">
-                    <j:set var="coverageDiff" value="${it.getChangeRequestCoverageDiffWithTargetBranch()}" />
+                    <j:set var="coverageDiff" value="${it.getLineCoverageDelta()}" />
                     <j:choose>
                         <j:when test="${coverageDiff gt 0}">
                             <h3>

--- a/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
@@ -271,7 +271,7 @@ public class CoverageChecksPublisherTest {
 
         when(result.getPreviousResult()).thenReturn(lastResult);
         when(result.getReferenceBuildUrl()).thenReturn(targetBuildLink);
-        when(result.getLineCoverageDelta()).thenReturn(targetBuildDiff);
+        when(result.getCoverageDelta(CoverageElement.LINE)).thenReturn(targetBuildDiff);
         when(result.getOwner()).thenReturn(build);
         when(build.getUrl()).thenReturn(BUILD_LINK);
         when(build.getPreviousSuccessfulBuild()).thenReturn(lastBuild);

--- a/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
@@ -270,8 +270,8 @@ public class CoverageChecksPublisherTest {
         CoverageResult result = createCoverageResult(lineCoverage, conditionCoverage);
 
         when(result.getPreviousResult()).thenReturn(lastResult);
-        when(result.getLinkToBuildThatWasUsedForComparison()).thenReturn(targetBuildLink);
-        when(result.getChangeRequestCoverageDiffWithTargetBranch()).thenReturn(targetBuildDiff);
+        when(result.getReferenceBuildUrl()).thenReturn(targetBuildLink);
+        when(result.getLineCoverageDelta()).thenReturn(targetBuildDiff);
         when(result.getOwner()).thenReturn(build);
         when(build.getUrl()).thenReturn(BUILD_LINK);
         when(build.getPreviousSuccessfulBuild()).thenReturn(lastBuild);


### PR DESCRIPTION
For now only the line coverage is calculating as diff, if `calculateDiffForChangeRequests` is enabled and a target branch is found.
* Extended  the diff coverage api by all existing coverage elements of target branch. 
* make variables names more meaningful: 
1. `changeRequestCoverageDiffWithTargetBranch` does not exist anymore and is part of the deltaResult map now. The getter, which is used until now `getChangeRequestCoverageDiffWithTargetBranch` is replaced by `getLineCoverageDelta()`, which extracts the corresponding metric from the deltaResults map. Therefore other plugins are able to use all delta metrics.
2. `linkToBuildThatWasUsedForComparison`is now the `referenceBuildUrl`

I'm not sure if this is all working as expected or if I'm breaking the api with it.. So can this please be checked carefully. Thanks in advance. Unit tests are still passing.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
