### PR TITLE
Use new delta values for branch coverage in checks title

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/CoverageChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageChecksPublisher.java
@@ -118,7 +118,7 @@ class CoverageChecksPublisher {
                 title.append(extractChecksTitle("Line", "target branch", lineCoverage,
                         result.getCoverageDelta(CoverageElement.LINE)));
             } else if (lastRatios.containsKey(CoverageElement.LINE)) {
-                 title.append(extractChecksTitle("Line", "last successful build", lineCoverage,
+                title.append(extractChecksTitle("Line", "last successful build", lineCoverage,
                         lineCoverage - lastRatios.get(CoverageElement.LINE).getPercentageFloat()));
             } else {
                 title.append(extractChecksTitle("Line", "", lineCoverage, 0));
@@ -129,7 +129,10 @@ class CoverageChecksPublisher {
 
         if (result.getCoverage(CoverageElement.CONDITIONAL) != null) {
             float branchCoverage = result.getCoverage(CoverageElement.CONDITIONAL).getPercentageFloat();
-            if (lastRatios.containsKey(CoverageElement.CONDITIONAL)) {
+            if (result.getReferenceBuildUrl() != null) {
+                title.append(extractChecksTitle("Branch", "target branch", branchCoverage,
+                        result.getCoverageDelta(CoverageElement.CONDITIONAL)));
+            } else if (lastRatios.containsKey(CoverageElement.CONDITIONAL)) {
                 title.append(extractChecksTitle("Branch", "last successful build", branchCoverage,
                         branchCoverage - lastRatios.get(CoverageElement.CONDITIONAL).getPercentageFloat()));
             } else {
@@ -145,7 +148,7 @@ class CoverageChecksPublisher {
     }
 
     private String extractChecksTitle(final String elementName, final String targetBuildName,
-                                      final float coverage, final float coverageDiff) {
+            final float coverage, final float coverageDiff) {
         StringBuilder title = new StringBuilder()
                 .append(elementName)
                 .append(String.format(": %.2f", coverage))

--- a/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
@@ -1,9 +1,11 @@
 package io.jenkins.plugins.coverage;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.jvnet.localizer.Localizable;
@@ -30,6 +32,11 @@ public class CoverageChecksPublisherTest {
     private static final String TARGET_BUILD_LINK = "job/pipeline-coding-style/job/master/3/";
     private static final String LAST_SUCCESSFUL_BUILD_LINK = "http://127.0.0.1:8080/job/pipeline-coding-style/view/change-requests/job/PR-3/110/";
     private static final String HEALTH_REPORT = "Coverage Healthy score is 100%";
+
+    @BeforeClass
+    public static void enforceEnglishLocale() {
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     @Test
     public void shouldConstructChecksDetailsWithLineAndMethodCoverage() {
@@ -72,7 +79,7 @@ public class CoverageChecksPublisherTest {
                 .withDetailsURL(JENKINS_BASE_URL + "/" + BUILD_LINK + COVERAGE_URL_NAME)
                 .withOutput(new ChecksOutputBuilder()
                         .withTitle("Line: 50.00% (+10.00% against target branch). " +
-                                "Branch: 50.00% (+20.00% against last successful build).")
+                                "Branch: 50.00% (+15.00% against target branch).")
                         .withSummary("* ### [Target branch build](" + JENKINS_BASE_URL + "/" + TARGET_BUILD_LINK + ")\n"
                                 + "* ### [Last successful build](" + JENKINS_BASE_URL + "/" + LAST_SUCCESSFUL_BUILD_LINK + ")\n"
                                 + "## " + HEALTH_REPORT + ".")
@@ -85,7 +92,8 @@ public class CoverageChecksPublisherTest {
                         .build())
                 .build();
 
-        CoverageResult result = createCoverageResult((float)0.4, (float)0.3, (float)0.5, (float)0.5, TARGET_BUILD_LINK, +10);
+        CoverageResult result = createCoverageResult((float)0.4, (float)0.3, (float)0.5, (float)0.5, TARGET_BUILD_LINK,
+                +10, +15);
         CoverageAction action = new CoverageAction(result);
 
         Localizable localizable = mock(Localizable.class);
@@ -107,11 +115,11 @@ public class CoverageChecksPublisherTest {
                 .withDetailsURL(JENKINS_BASE_URL + "/job/pipeline-coding-style/job/PR-3/49/coverage")
                 .withOutput(new ChecksOutputBuilder()
                         .withTitle("Line: 50.00% (-10.00% against target branch). " +
-                                "Branch: 50.00% (-20.00% against last successful build).")
+                                "Branch: 50.00% (-15.00% against target branch).")
                         .withSummary("* ### [Target branch build](" + JENKINS_BASE_URL + "/" + TARGET_BUILD_LINK + ")\n"
                                 + "* ### [Last successful build](" + JENKINS_BASE_URL + "/" + LAST_SUCCESSFUL_BUILD_LINK + ")\n"
                                 + "## " + HEALTH_REPORT + ".")
-                        .withText("## Conditional\n* :white_check_mark: Coverage: 50%\n* :arrow_down: Trend: 20%\n"
+                        .withText("## Conditional\n* :white_check_mark: Coverage: 50%\n* :arrow_down: Trend: 15%\n"
                                 + "## Line\n* :white_check_mark: Coverage: 50%\n* :arrow_down: Trend: 10%\n")
                         .withText("||Conditional|Line|\n" +
                                 "|:-:|:-:|:-:|\n" +
@@ -120,7 +128,8 @@ public class CoverageChecksPublisherTest {
                         .build())
                 .build();
 
-        CoverageResult result = createCoverageResult((float)0.6, (float)0.7, (float)0.5, (float)0.5, TARGET_BUILD_LINK, -10);
+        CoverageResult result = createCoverageResult((float)0.6, (float)0.7, (float)0.5, (float)0.5, TARGET_BUILD_LINK,
+                -10, -15);
         CoverageAction action = new CoverageAction(result);
 
         Localizable localizable = mock(Localizable.class);
@@ -142,7 +151,7 @@ public class CoverageChecksPublisherTest {
                 .withDetailsURL(JENKINS_BASE_URL + "/job/pipeline-coding-style/job/PR-3/49/coverage")
                 .withOutput(new ChecksOutputBuilder()
                         .withTitle("Line: 60.00% (+0.00% against target branch). " +
-                                "Branch: 40.00% (+0.00% against last successful build).")
+                                "Branch: 40.00% (+0.00% against target branch).")
                         .withSummary("* ### [Target branch build](" + JENKINS_BASE_URL + "/" + TARGET_BUILD_LINK + ")\n"
                                 + "* ### [Last successful build](" + JENKINS_BASE_URL + "/" + LAST_SUCCESSFUL_BUILD_LINK + ")\n"
                                 + "## " + HEALTH_REPORT + ".")
@@ -153,7 +162,8 @@ public class CoverageChecksPublisherTest {
                         .build())
                 .build();
 
-        CoverageResult result = createCoverageResult((float)0.6, (float)0.4, (float)0.6, (float)0.4, TARGET_BUILD_LINK, 0);
+        CoverageResult result = createCoverageResult((float)0.6, (float)0.4, (float)0.6, (float)0.4, TARGET_BUILD_LINK, 0,
+                0);
         CoverageAction action = new CoverageAction(result);
 
         Localizable localizable = mock(Localizable.class);
@@ -187,7 +197,7 @@ public class CoverageChecksPublisherTest {
                         .build())
                 .build();
 
-        CoverageResult result = createCoverageResult((float)0.5, (float)0.3, (float)0.6, (float)0.4, null, 0);
+        CoverageResult result = createCoverageResult((float)0.5, (float)0.3, (float)0.6, (float)0.4, null, 0, -10);
         CoverageAction action = new CoverageAction(result);
 
         Localizable localizable = mock(Localizable.class);
@@ -267,8 +277,8 @@ public class CoverageChecksPublisherTest {
     }
 
     private CoverageResult createCoverageResult(final float lastLineCoverage, final float lastConditionCoverage,
-                                                final float lineCoverage, final float conditionCoverage,
-                                                final String targetBuildLink, final float targetBuildDiff) {
+            final float lineCoverage, final float conditionCoverage,
+            final String targetBuildLink, final float targetLineDiff, final float targetBranchDiff) {
         Run build = mock(Run.class);
         Run lastBuild = mock(Run.class);
         CoverageResult lastResult = createCoverageResult(lastLineCoverage, lastConditionCoverage);
@@ -276,7 +286,8 @@ public class CoverageChecksPublisherTest {
 
         when(result.getPreviousResult()).thenReturn(lastResult);
         when(result.getReferenceBuildUrl()).thenReturn(targetBuildLink);
-        when(result.getCoverageDelta(CoverageElement.LINE)).thenReturn(targetBuildDiff);
+        when(result.getCoverageDelta(CoverageElement.LINE)).thenReturn(targetLineDiff);
+        when(result.getCoverageDelta(CoverageElement.CONDITIONAL)).thenReturn(targetBranchDiff);
         when(result.getOwner()).thenReturn(build);
         when(build.getUrl()).thenReturn(BUILD_LINK);
         when(build.getPreviousSuccessfulBuild()).thenReturn(lastBuild);


### PR DESCRIPTION
Followup to #198: Show delta of line **and** branch coverage with respect to target branch in GitHub checks. 