### PR TITLE
Fix `splitPackages` for some corner cases

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/model/CoverageNode.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/CoverageNode.java
@@ -347,11 +347,21 @@ public final class CoverageNode implements Serializable {
      */
     public void splitPackages() {
         if (CoverageMetric.MODULE.equals(metric)) {
-            List<CoverageNode> allPackages = new ArrayList<>(children);
-            children.clear();
-            for (CoverageNode aPackage : allPackages) {
-                Deque<String> packageLevels = new ArrayDeque<>(Arrays.asList(aPackage.getName().split("\\.")));
-                insertPackage(aPackage, packageLevels);
+            List<CoverageNode> allPackages = children.stream()
+                    .filter(child -> CoverageMetric.PACKAGE.equals(child.getMetric()))
+                    .collect(Collectors.toList());
+            if (!allPackages.isEmpty()) {
+                children.clear();
+                for (CoverageNode packageNode : allPackages) {
+                    String[] packageParts = packageNode.getName().split("\\.");
+                    if (packageParts.length > 1) {
+                        Deque<String> packageLevels = new ArrayDeque<>(Arrays.asList(packageParts));
+                        insertPackage(packageNode, packageLevels);
+                    }
+                    else {
+                        add(packageNode);
+                    }
+                }
             }
         }
     }

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoverageNodeTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoverageNodeTest.java
@@ -19,6 +19,44 @@ class CoverageNodeTest extends AbstractCoverageTest {
     private static final String PROJECT_NAME = "Java coding style: jacoco-codingstyle.xml";
 
     @Test
+    void shouldSplitPackagesWithoutPackageNodes() {
+        CoverageNode root = new CoverageNode(CoverageMetric.MODULE, "Root");
+        assertThat(root.getAll(PACKAGE)).hasSize(0);
+        root.splitPackages();
+        assertThat(root.getAll(PACKAGE)).hasSize(0);
+
+        root.add(new CoverageNode(CoverageMetric.FILE, "file.c"));
+        root.splitPackages();
+        assertThat(root.getAll(PACKAGE)).hasSize(0);
+    }
+
+    @Test
+    void shouldSplitPackagesWithoutName() {
+        CoverageNode root = new CoverageNode(CoverageMetric.MODULE, "Root");
+        assertThat(root.getAll(PACKAGE)).hasSize(0);
+        root.splitPackages();
+        assertThat(root.getAll(PACKAGE)).hasSize(0);
+
+        root.add(new CoverageNode(CoverageMetric.PACKAGE, ""));
+        assertThat(root.getAll(PACKAGE)).hasSize(1);
+        root.splitPackages();
+        assertThat(root.getAll(PACKAGE)).hasSize(1);
+    }
+
+    @Test
+    void shouldSplitPackagesWithSingleDot() {
+        CoverageNode root = new CoverageNode(CoverageMetric.MODULE, "Root");
+        assertThat(root.getAll(PACKAGE)).hasSize(0);
+        root.splitPackages();
+        assertThat(root.getAll(PACKAGE)).hasSize(0);
+
+        root.add(new CoverageNode(CoverageMetric.PACKAGE, "."));
+        assertThat(root.getAll(PACKAGE)).hasSize(1);
+        root.splitPackages();
+        assertThat(root.getAll(PACKAGE)).hasSize(1);
+    }
+
+    @Test
     void shouldConvertCodingStyleToTree() {
         CoverageNode tree = readExampleReport();
 


### PR DESCRIPTION
- If the package name contains a single dot, then splitting broke with an exception.
- If the module node does not contain packages, then the next sub nodes have been split.
- If the package name does not contain dots, then the package was deleted.

Fixes #223.