### PR TITLE
Do not fail when report is missing in reference build

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -235,7 +235,7 @@ public class CoverageProcessor {
             previousResult = getPreviousResult(run.getPreviousBuild());
         }
 
-        if (!previousResult.isPresent()) {
+        if (!previousResult.isPresent() || previousResult.get().getResult() == null) {
             log.logInfo("-> Found no reference result in reference build");
 
             return Optional.empty();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [TODO] Ensure you have provided tests - that demonstrates feature works or fixes the issue

As an administrator I want to be able to remove the coverage .xml files for old builds without breaking new builds. Clearly this should be done using some log-rotate feature in Jenkins, but it would be nice if the plugin could handle the case when I do it by simply removing the files from the filesystem.
