### PR TITLE
Replace JSR 305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/adapter/CoberturaReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/CoberturaReportAdapter.java
@@ -1,9 +1,9 @@
 package io.jenkins.plugins.coverage.adapter;
 
 import java.io.File;
-import javax.annotation.Nonnull;
 import javax.xml.transform.TransformerException;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -74,7 +74,7 @@ public final class CoberturaReportAdapter extends JavaXMLCoverageReportAdapter {
             return "coverage".equals(e.getLocalName());
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.CoberturaReportAdapter_displayName();

--- a/src/main/java/io/jenkins/plugins/coverage/adapter/CoverageReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/CoverageReportAdapter.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.coverage.adapter;
 
 import com.google.common.collect.Lists;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.AbortException;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -14,7 +15,6 @@ import io.jenkins.plugins.coverage.threshold.Threshold;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.w3c.dom.Document;
 
-import javax.annotation.CheckForNull;
 import java.io.File;
 import java.io.IOException;
 import java.util.LinkedList;

--- a/src/main/java/io/jenkins/plugins/coverage/adapter/IstanbulCoberturaReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/IstanbulCoberturaReportAdapter.java
@@ -1,10 +1,10 @@
 package io.jenkins.plugins.coverage.adapter;
 
 import java.util.List;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -68,7 +68,7 @@ public class IstanbulCoberturaReportAdapter extends XMLCoverageReportAdapter {
             return CoverageElement.COVERAGE_ELEMENT_TYPE_JAVASCRIPT;
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.IstanbulCoberturaReportAdapter_displayName();

--- a/src/main/java/io/jenkins/plugins/coverage/adapter/JacocoReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/JacocoReportAdapter.java
@@ -1,8 +1,8 @@
 package io.jenkins.plugins.coverage.adapter;
 
 import java.util.List;
-import javax.annotation.Nonnull;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -50,7 +50,7 @@ public final class JacocoReportAdapter extends JavaXMLCoverageReportAdapter {
             super(JacocoReportAdapter.class);
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.JacocoReportAdapter_displayName();

--- a/src/main/java/io/jenkins/plugins/coverage/adapter/XMLCoverageReportAdapter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/adapter/XMLCoverageReportAdapter.java
@@ -1,12 +1,12 @@
 package io.jenkins.plugins.coverage.adapter;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.jenkins.plugins.coverage.adapter.util.XMLUtils;
 import io.jenkins.plugins.coverage.exception.CoverageException;
 import org.apache.commons.lang.StringUtils;
 import org.w3c.dom.Document;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
 import javax.xml.transform.stream.StreamSource;
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/src/main/java/io/jenkins/plugins/coverage/detector/AntPathReportDetector.java
+++ b/src/main/java/io/jenkins/plugins/coverage/detector/AntPathReportDetector.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.coverage.detector;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Run;
@@ -11,7 +12,6 @@ import jenkins.MasterToSlaveFileCallable;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -53,7 +53,7 @@ public class AntPathReportDetector extends ReportDetector {
             super(AntPathReportDetector.class);
         }
 
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.AntPathDetector_displayName();

--- a/src/main/java/io/jenkins/plugins/coverage/detector/ReportDetector.java
+++ b/src/main/java/io/jenkins/plugins/coverage/detector/ReportDetector.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.coverage.detector;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -10,7 +11,6 @@ import io.jenkins.plugins.coverage.adapter.CoverageReportAdapterDescriptor;
 import io.jenkins.plugins.coverage.exception.CoverageException;
 import org.apache.commons.io.FileUtils;
 
-import javax.annotation.CheckForNull;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;

--- a/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
+++ b/src/main/java/io/jenkins/plugins/coverage/source/DefaultSourceFileResolver.java
@@ -21,6 +21,7 @@
  */
 package io.jenkins.plugins.coverage.source;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Descriptor;
@@ -36,7 +37,6 @@ import org.apache.commons.io.FileUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.Nonnull;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -162,11 +162,11 @@ public class DefaultSourceFileResolver extends SourceFileResolver {
         private final Map<String, FilePath> sourceFileMapping;
 
         SourceFilePainter(
-                @Nonnull String sourceFilePath,
-                @Nonnull CoveragePaint paint,
-                @Nonnull FilePath destination,
-                @Nonnull Set<String> possiblePaths,
-                @Nonnull Map<String, FilePath> sourceFileMapping
+                @NonNull String sourceFilePath,
+                @NonNull CoveragePaint paint,
+                @NonNull FilePath destination,
+                @NonNull Set<String> possiblePaths,
+                @NonNull Map<String, FilePath> sourceFileMapping
         ) {
             this.sourceFilePath = sourceFilePath;
             this.paint = paint;

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageElement.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageElement.java
@@ -1,8 +1,9 @@
 package io.jenkins.plugins.coverage.targets;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.io.Serializable;
 import java.util.Objects;
-import javax.annotation.Nonnull;
 
 public class CoverageElement implements Comparable<CoverageElement>, Serializable {
     private static final long serialVersionUID = 6722992955158201174L;
@@ -64,7 +65,7 @@ public class CoverageElement implements Comparable<CoverageElement>, Serializabl
     }
 
     @Override
-    public int compareTo(@Nonnull final CoverageElement coverageElement) {
+    public int compareTo(@NonNull final CoverageElement coverageElement) {
         if (this.order == coverageElement.order) {
             return 0;
         }


### PR DESCRIPTION
Since we moved from JSR-305 annotations to Spotbugs a while agon in core [](https://github.com/jenkinsci/jenkins/pull/4604) we might also do this here :)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
