### PR TITLE
Use `${resURL}` rather than `${rootURL}` when resolving JS files

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/model/CoverageBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/CoverageBuildAction.java
@@ -253,7 +253,7 @@ public class CoverageBuildAction extends BuildAction<CoverageNode> implements He
         protected void configureXStream(final XStream2 xStream) {
             xStream.alias("node", CoverageNode.class);
             xStream.alias("leaf", CoverageLeaf.class);
-            xStream.addImmutableType(CoverageMetric.class);
+            xStream.addImmutableType(CoverageMetric.class, false);
             xStream.registerConverter(new MetricsConverter());
         }
 

--- a/src/main/resources/io/jenkins/plugins/coverage/CoveragePullRequestMonitoringPortlet/monitor.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/CoveragePullRequestMonitoringPortlet/monitor.jelly
@@ -8,7 +8,7 @@
     <div id="coverage-pr-portlet" data="${it.getCoverageResultsAsJsonModel()}"
          style="width: ${it.preferredWidth}px; height: ${it.preferredHeight - 100}px;"/>
 
-    <script type="text/javascript" src="${rootURL}/plugin/code-coverage-api/scripts/coverage-portlet.js"/>
+    <script type="text/javascript" src="${resURL}/plugin/code-coverage-api/scripts/coverage-portlet.js"/>
 
     <script type="text/javascript">
         new CoveragePortletChart('coverage-pr-portlet');

--- a/src/main/resources/io/jenkins/plugins/coverage/model/CoverageViewModel/index.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/model/CoverageViewModel/index.jelly
@@ -9,6 +9,7 @@
     <st:adjunct includes="io.jenkins.plugins.data-tables"/>
 
     <link rel="stylesheet" href="${resURL}/plugin/code-coverage-api/css/custom-style.css"/>
+    <script type="text/javascript" src="${resURL}/plugin/code-coverage-api/js/charts.js"/>
 
     <div class="row py-3 flex-nowrap">
       <div class="col d-flex">
@@ -65,8 +66,6 @@
   </bs:page>
 
   <c:chart-setup id="coverage-history"/>
-
-  <script type="text/javascript" src="${rootURL}/plugin/code-coverage-api/js/charts.js"/>
 
   <script>
     const viewProxy =<st:bind value="${it}"/>;


### PR DESCRIPTION
This fixes a bug when Jenkins is not running with the default prefix, see
https://github.com/jenkinsci/code-coverage-api-plugin/issues/242 for details.

