### PR TITLE
Rewrite source code painting and archiving 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
     <gson.version>2.8.9</gson.version>
     <workflow-cps.version>2.94</workflow-cps.version>
     <workflow-multibranch.version>2.24</workflow-multibranch.version>
+
+    <docker-fixtures.version>1.11</docker-fixtures.version>
   </properties>
 
   <developers>
@@ -197,6 +199,34 @@
       <artifactId>workflow-support</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Docker Agents -->
+    <dependency>
+      <groupId>org.jenkins-ci.test</groupId>
+      <artifactId>docker-fixtures</artifactId>
+      <version>${docker-fixtures.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-slaves</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>git-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,12 @@
       <artifactId>git-client</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>timestamper</artifactId>
+      <version>1.15</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/src/main/java/io/jenkins/plugins/coverage/CoverageNodeConverter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageNodeConverter.java
@@ -1,11 +1,16 @@
 package io.jenkins.plugins.coverage;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 import io.jenkins.plugins.coverage.model.Coverage;
 import io.jenkins.plugins.coverage.model.CoverageLeaf;
 import io.jenkins.plugins.coverage.model.CoverageMetric;
 import io.jenkins.plugins.coverage.model.CoverageNode;
+import io.jenkins.plugins.coverage.model.FileCoverageNode;
+import io.jenkins.plugins.coverage.model.PackageCoverageNode;
 import io.jenkins.plugins.coverage.targets.CoverageElement;
 import io.jenkins.plugins.coverage.targets.CoveragePaint;
 import io.jenkins.plugins.coverage.targets.CoverageResult;
@@ -17,34 +22,41 @@ import io.jenkins.plugins.coverage.targets.Ratio;
  * @author Ullrich Hafner
  */
 public class CoverageNodeConverter {
+    private final Map<CoverageNode, CoveragePaint> paintedFiles = new HashMap<>();
+
     /**
      * Converts a {@link CoverageResult} instance to the corresponding {@link CoverageNode} instance.
      *
      * @param result
      *         the result that should be converted
+     *
+     * @return the root node of the coverage tree
      */
-    public static CoverageNode convert(final CoverageResult result) {
+    public CoverageNode convert(final CoverageResult result) {
         CoverageNode node = createNode(result);
         attachLineAndBranchHits(result, node);
 
         return node;
     }
 
-    private static void attachLineAndBranchHits(final CoverageResult result, final CoverageNode node) {
+    private void attachLineAndBranchHits(final CoverageResult result, final CoverageNode node) {
         CoveragePaint paint = result.getPaint();
         if (paint != null) {
             int[] uncoveredLines = paint.getUncoveredLines();
             if (uncoveredLines.length > 0) {
                 node.setUncoveredLines(uncoveredLines);
             }
+            if (node.getMetric().equals(CoverageMetric.FILE)) {
+                paintedFiles.put(node, paint);
+            }
         }
     }
 
-    private static CoverageNode createNode(final CoverageResult result) {
+    private CoverageNode createNode(final CoverageResult result) {
         CoverageElement element = result.getElement();
         CoverageMetric metric = CoverageMetric.valueOf(element.getName());
         if (result.getChildren().isEmpty()) {
-            CoverageNode coverageNode = new CoverageNode(metric, result.getName());
+            CoverageNode coverageNode = createNode(metric, result);
             for (Map.Entry<CoverageElement, Ratio> coverage : result.getLocalResults().entrySet()) {
                 Ratio ratio = coverage.getValue();
                 CoverageLeaf leaf = new CoverageLeaf(CoverageMetric.valueOf(coverage.getKey().getName()),
@@ -54,7 +66,7 @@ public class CoverageNodeConverter {
             return coverageNode;
         }
         else {
-            CoverageNode coverageNode = new CoverageNode(metric, result.getName());
+            CoverageNode coverageNode = createNode(metric, result);
             for (String childKey : result.getChildren()) {
                 CoverageResult childResult = result.getChild(childKey);
                 coverageNode.add(convert(childResult));
@@ -63,4 +75,17 @@ public class CoverageNodeConverter {
         }
     }
 
+    private CoverageNode createNode(final CoverageMetric metric, final CoverageResult result) {
+        if (metric.equals(CoverageMetric.FILE)) {
+            return new FileCoverageNode(result.getName(), result.getRelativeSourcePath());
+        }
+        if (metric.equals(CoverageMetric.PACKAGE)) {
+            return new PackageCoverageNode(result.getName());
+        }
+        return new CoverageNode(metric, result.getName());
+    }
+
+    public Set<Entry<CoverageNode, CoveragePaint>> getPaintedFiles() {
+        return paintedFiles.entrySet();
+    }
 }

--- a/src/main/java/io/jenkins/plugins/coverage/model/CoverageNode.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/CoverageNode.java
@@ -17,6 +17,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
+
 import edu.hm.hafner.util.Ensure;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
@@ -26,7 +28,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
  * @author Ullrich Hafner
  */
 @SuppressWarnings("PMD.GodClass")
-public final class CoverageNode implements Serializable {
+public class CoverageNode implements Serializable {
     private static final long serialVersionUID = -6608885640271135273L;
 
     private static final Coverage COVERED_NODE = new Coverage(1, 0);
@@ -43,6 +45,7 @@ public final class CoverageNode implements Serializable {
     private CoverageNode parent;
     private int[] uncoveredLines = EMPTY_ARRAY;
 
+
     /**
      * Creates a new coverage item node with the given name.
      *
@@ -54,6 +57,38 @@ public final class CoverageNode implements Serializable {
     public CoverageNode(final CoverageMetric metric, final String name) {
         this.metric = metric;
         this.name = name;
+    }
+
+    CoverageNode getParent() {
+        if (parent == null) {
+            throw new NullPointerException("Parent is not set");
+        }
+        return parent;
+    }
+
+    /**
+     * Returns the source code path of this node.
+     *
+     * @return the element type
+     */
+    public String getPath() {
+        return StringUtils.EMPTY;
+    }
+
+    protected String mergePath(final String localPath) {
+        if (hasParent()) {
+            String parentPath = getParent().getPath();
+            if (StringUtils.isBlank(parentPath)) {
+                return localPath;
+            }
+            if (StringUtils.isBlank(localPath)) {
+                return parentPath;
+            }
+            return parentPath + "/" + localPath;
+        }
+
+        return localPath;
+
     }
 
     /**
@@ -384,7 +419,7 @@ public final class CoverageNode implements Serializable {
             }
 
         }
-        CoverageNode newNode = new CoverageNode(CoverageMetric.PACKAGE, childName);
+        CoverageNode newNode = new PackageCoverageNode(childName);
         add(newNode);
         return newNode;
     }

--- a/src/main/java/io/jenkins/plugins/coverage/model/FileCoverageNode.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/FileCoverageNode.java
@@ -1,0 +1,35 @@
+package io.jenkins.plugins.coverage.model;
+
+import org.apache.commons.lang3.StringUtils;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+
+/**
+ * A {@link CoverageNode} for a specific file. It stores the actual file name along the coverage information.
+ *
+ * @author Ullrich Hafner
+ */
+public class FileCoverageNode extends CoverageNode {
+    private static final long serialVersionUID = -3795695377267542624L;
+
+    private final String sourcePath;
+
+    /**
+     * Creates a new {@link FileCoverageNode} with the given name.
+     *
+     * @param name
+     *         the human-readable name of the node
+     * @param sourcePath
+     *         optional path to the source code of this node
+     */
+    public FileCoverageNode(final String name, @CheckForNull final String sourcePath) {
+        super(CoverageMetric.FILE, name);
+
+        this.sourcePath = StringUtils.defaultString(sourcePath);
+    }
+
+    @Override
+    public String getPath() {
+        return mergePath(sourcePath);
+    }
+}

--- a/src/main/java/io/jenkins/plugins/coverage/model/PackageCoverageNode.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/PackageCoverageNode.java
@@ -1,0 +1,25 @@
+package io.jenkins.plugins.coverage.model;
+
+/**
+ * A {@link CoverageNode} for a specific package. It converts a package structure to a corresponding path structure.
+ *
+ * @author Ullrich Hafner
+ */
+public class PackageCoverageNode extends CoverageNode {
+    private static final long serialVersionUID = 8236436628673022634L;
+
+    /**
+     * Creates a new coverage item node with the given name.
+     *
+     * @param name
+     *         the human-readable name of the node
+     */
+    public PackageCoverageNode(final String name) {
+        super(CoverageMetric.PACKAGE, name);
+    }
+
+    @Override
+    public String getPath() {
+        return mergePath(getName().replaceAll("\\.", "/"));
+    }
+}

--- a/src/main/java/io/jenkins/plugins/coverage/source/SourcePainter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/source/SourcePainter.java
@@ -1,0 +1,210 @@
+package io.jenkins.plugins.coverage.source;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import edu.hm.hafner.util.FilteredLog;
+
+import hudson.remoting.VirtualChannel;
+import jenkins.MasterToSlaveFileCallable;
+
+import io.jenkins.plugins.coverage.model.CoverageNode;
+import io.jenkins.plugins.coverage.targets.CoveragePaint;
+
+/**
+ * Paints a collection of files with the recorded coverage information and stores all files in a temporary directory.
+ *
+ * @author Ullrich Hafner
+ */
+public class SourcePainter implements Serializable {
+    /*
+     TODO:  ideally we would scan for coverage reports on the agent and covert the reports there as well. Then we
+            can simply create the painted files on the agent without transferring the list of nodes that will be painted.
+            Additionally we could strip the node tree at the file level, since the lower nodes are only required for
+            the painting.
+     */
+    private static final long serialVersionUID = -7390586016893061868L;
+
+    public void paintSources(final List<PaintedNode> paintedFiles, final FilteredLog log, final File workspace,
+            final Collection<String> sourceFolders, final Charset sourceEncoding) {
+        try {
+            Path outputFolder = workspace.toPath().resolve("coverage-sources");
+            Files.createDirectory(outputFolder);
+
+            log.logInfo("Painting %d files in folder '%s'", paintedFiles.size(), outputFolder);
+            paintedFiles.parallelStream().forEach(
+                    f -> paintFile(f, workspace.toPath(), sourceFolders, log, sourceEncoding));
+            log.logInfo("-> finished painting successfully");
+        }
+        catch (IOException exception) {
+            log.logException(exception,
+                    "Cannot create temporary directory in folder '%s' for the painted source files", workspace);
+        }
+    }
+
+    private void paintFile(final PaintedNode fileNode, final Path workspace,
+            final Collection<String> sourceFolders, final FilteredLog log, final Charset sourceEncoding) {
+        String sourcePath = fileNode.getNode().getPath();
+        Optional<Path> sourceFile = findSourceFile(workspace, sourcePath, sourceFolders, log);
+        sourceFile.ifPresent(path -> paint(fileNode.getPaint(), sourcePath, path, sourceEncoding, workspace, log));
+    }
+
+    private void paint(final CoveragePaint paint, final String fileName, final Path inputPath, final Charset charset,
+            final Path workspace, final FilteredLog log) {
+        Path outputPath = workspace.resolve(getTempName(fileName));
+        try {
+            log.logInfo("Writing painted source of '%s' to '%s'", fileName, outputPath);
+            try (BufferedWriter output = Files.newBufferedWriter(outputPath)) {
+                List<String> lines = Files.readAllLines(inputPath, charset);
+                for (int line = 0; line < lines.size(); line++) {
+                    String content = lines.get(line);
+                    paintLine(line, content, paint, output);
+                }
+                paint.setTotalLines(lines.size());
+            }
+        }
+        catch (IOException exception) {
+            log.logException(exception, "Can't write coverage paint of '%s' to source file '%s'", fileName, outputPath);
+        }
+    }
+
+    private void paintLine(final int line, final String content, final CoveragePaint paint,
+            final BufferedWriter output) throws IOException {
+        if (paint.isPainted(line)) {
+            final int hits = paint.getHits(line);
+            final int branchCoverage = paint.getBranchCoverage(line);
+            final int branchTotal = paint.getBranchTotal(line);
+            final int coveragePercent = (hits == 0) ? 0 : (int) (branchCoverage * 100.0 / branchTotal);
+            if (paint.getHits(line) > 0) {
+                if (branchTotal == branchCoverage) {
+                    output.write("<tr class=\"coverFull\">\n");
+                }
+                else {
+                    output.write("<tr class=\"coverPart\" title=\"Line " + line + ": Conditional coverage "
+                            + coveragePercent + "% ("
+                            + branchCoverage + "/" + branchTotal + ")\">\n");
+                }
+            }
+            else {
+                output.write("<tr class=\"coverNone\">\n");
+            }
+            output.write("<td class=\"line\"><a name='" + line + "'>" + line + "</a></td>\n");
+            output.write("<td class=\"hits\">" + hits + "</td>\n");
+        }
+        else {
+            output.write("<tr class=\"noCover\">\n");
+            output.write("<td class=\"line\"><a name='" + line + "'>" + line + "</a></td>\n");
+            output.write("<td class=\"hits\"></td>\n");
+        }
+        output.write("<td class=\"code\">"
+                + content.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\n", "")
+                .replace("\r", "")
+                .replace(" ",
+                        "&nbsp;")
+                .replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;") + "</td>\n");
+        output.write("</tr>\n");
+
+    }
+
+    /**
+     * Returns a file name for a temporary file that will hold the contents of the source.
+     *
+     * @param fileName
+     *         the file name to convert
+     *
+     * @return the temporary name
+     */
+    private static String getTempName(final String fileName) {
+        return Integer.toHexString(fileName.hashCode()) + ".tmp";
+    }
+
+    private Optional<Path> findSourceFile(final Path workspace, final String nodePath,
+            final Collection<String> sourceFolders, final FilteredLog log) {
+        try {
+            String relativeSourcePath = nodePath;
+            Path absolutePath = Paths.get(relativeSourcePath);
+            if (Files.exists(absolutePath)) {
+                return Optional.of(absolutePath);
+            }
+            Path relativePath = workspace.resolve(relativeSourcePath);
+            if (Files.exists(relativePath)) {
+                return Optional.of(relativePath);
+            }
+
+            for (String sourceFolder : sourceFolders) {
+                Path sourcePath = workspace.resolve(sourceFolder).resolve(relativeSourcePath);
+                if (Files.exists(sourcePath)) {
+                    return Optional.of(sourcePath);
+                }
+            }
+            log.logError("Source file '%s' not found", nodePath);
+        }
+        catch (InvalidPathException exception) {
+            log.logException(exception, "No valid path in coverage node: '%s'", nodePath);
+        }
+        return Optional.empty();
+    }
+
+    public static class AgentPainter extends MasterToSlaveFileCallable<FilteredLog> {
+        private static final long serialVersionUID = 3966282357309568323L;
+
+        private final List<PaintedNode> paintedFiles;
+
+        public AgentPainter(final Set<Entry<CoverageNode, CoveragePaint>> paintedFiles) {
+            this.paintedFiles = paintedFiles.stream()
+                    .map(e -> new PaintedNode(e.getKey(), e.getValue()))
+                    .collect(Collectors.toList());
+        }
+
+        @Override
+        public FilteredLog invoke(final File workspace, final VirtualChannel channel)
+                throws IOException, InterruptedException {
+            FilteredLog log = new FilteredLog("Errors during source code painting:");
+
+            SourcePainter sourcePainter = new SourcePainter();
+            sourcePainter.paintSources(paintedFiles, log, workspace, Arrays.asList("checkout/src/main/java"), StandardCharsets.UTF_8);
+
+            return log;
+        }
+
+
+    }
+
+    static class PaintedNode implements Serializable {
+        private static final long serialVersionUID = -6044649044983631852L;
+
+        private final CoverageNode node;
+        private final CoveragePaint paint;
+
+        PaintedNode(final CoverageNode node, final CoveragePaint paint) {
+            this.node = node;
+            this.paint = paint;
+        }
+
+        public CoverageNode getNode() {
+            return node;
+        }
+
+        public CoveragePaint getPaint() {
+            return paint;
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/coverage/model/AbstractCoverageTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/AbstractCoverageTest.java
@@ -48,7 +48,7 @@ public class AbstractCoverageTest extends ResourceTest {
     }
 
     CoverageNode readNode(final String fileName) {
-        return CoverageNodeConverter.convert(readResult(fileName));
+        return new CoverageNodeConverter().convert(readResult(fileName));
     }
 
     protected CoverageResult readReport(final String fileName) throws CoverageException {

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoverageNodeTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoverageNodeTest.java
@@ -6,8 +6,6 @@ import java.util.Optional;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 
-import io.jenkins.plugins.coverage.CoverageNodeConverter;
-
 import static io.jenkins.plugins.coverage.model.Assertions.*;
 
 /**
@@ -155,12 +153,14 @@ class CoverageNodeTest extends AbstractCoverageTest {
 
     @Test
     void shouldComputeDelta() {
-        CoverageNode tree = CoverageNodeConverter.convert(readResult("jacoco-analysis-model.xml"));
+        CoverageNode tree = readNode("jacoco-analysis-model.xml");
 
         String checkStyleParser = "CheckStyleParser.java";
         Optional<CoverageNode> wrappedCheckStyle = tree.find(CoverageMetric.FILE, checkStyleParser);
         assertThat(wrappedCheckStyle).isNotEmpty().hasValueSatisfying(
-                node -> assertThat(node).hasName(checkStyleParser)
+                node -> assertThat(node)
+                        .hasName(checkStyleParser)
+                        .hasPath("edu/hm/hafner/analysis/parser/checkstyle/CheckStyleParser.java")
         );
 
         CoverageNode checkStyle = wrappedCheckStyle.get();
@@ -174,7 +174,9 @@ class CoverageNodeTest extends AbstractCoverageTest {
         String pmdParser = "PmdParser.java";
         Optional<CoverageNode> wrappedPmd = tree.find(CoverageMetric.FILE, pmdParser);
         assertThat(wrappedPmd).isNotEmpty().hasValueSatisfying(
-                node -> assertThat(node).hasName(pmdParser)
+                node -> assertThat(node)
+                        .hasName(pmdParser)
+                        .hasPath("edu/hm/hafner/analysis/parser/pmd/PmdParser.java")
         );
 
         CoverageNode pmd = wrappedPmd.get();
@@ -202,7 +204,7 @@ class CoverageNodeTest extends AbstractCoverageTest {
 
     @Test
     void shouldSplitComplexPackageStructure() {
-        CoverageNode tree = CoverageNodeConverter.convert(readResult("jacoco-analysis-model.xml"));
+        CoverageNode tree = readNode("jacoco-analysis-model.xml");
 
         assertThat(tree.getAll(PACKAGE)).hasSize(18);
 
@@ -215,7 +217,7 @@ class CoverageNodeTest extends AbstractCoverageTest {
     void shouldNotSplitPackagesIfOnWrongHierarchyNode() {
         CoverageNode tree = readExampleReport();
         CoverageNode packageNode = tree.getChildren().get(0);
-        assertThat(packageNode).hasName("edu.hm.hafner.util");
+        assertThat(packageNode).hasName("edu.hm.hafner.util").hasPath("edu/hm/hafner/util");
 
         List<CoverageNode> files = packageNode.getChildren();
 
@@ -293,6 +295,6 @@ class CoverageNodeTest extends AbstractCoverageTest {
     }
 
     private CoverageNode readExampleReport() {
-        return CoverageNodeConverter.convert(readResult("jacoco-codingstyle.xml"));
+        return readNode("jacoco-codingstyle.xml");
     }
 }

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
@@ -107,9 +107,8 @@ public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
                                 + "branches: [[name: '6bd346bbcc9779467ce657b2618ab11e38e28c2c' ]],\n"
                                 + "userRemoteConfigs: [[url: '" + "https://github.com/jenkinsci/analysis-model.git" + "']],\n"
                                 + "extensions: [[$class: 'RelativeTargetDirectory', \n"
-                                + "            relativeTargetDir: 'forensics-api']]])\n"
-                        + "sh 'mvn verify'\n"
-                        + "publishCoverage adapters: [jacocoAdapter('" + FILE_NAME + "')]\n"
+                                + "            relativeTargetDir: 'checkout']]])\n"
+                        + "    publishCoverage adapters: [jacocoAdapter('" + FILE_NAME + "')]\n"
                         + "}", true));
 
         return job;

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
@@ -29,7 +29,6 @@ import io.jenkins.plugins.coverage.adapter.JacocoReportAdapter;
 import io.jenkins.plugins.util.IntegrationTestWithJenkinsPerSuite;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.Assumptions.*;
 
 /**
  * Integration tests for the coverage API plugin.
@@ -75,8 +74,6 @@ public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
     /** Example integration test for a freestyle build with code coverage that runs on an agent. */
     @Test
     public void coverageFreeStyleOnAgent() throws IOException, InterruptedException {
-        assumeThat(isWindows()).as("Running on Windows").isFalse();
-
         DumbSlave agent = createDockerContainerAgent(javaDockerRule.get());
         FreeStyleProject project = createFreeStyleProject();
         project.setAssignedNode(agent);
@@ -93,8 +90,6 @@ public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
     /** Example integration test for a pipeline with code coverage that runs on an agent. */
     @Test
     public void coveragePipelineOnAgentNode() throws IOException, InterruptedException {
-        assumeThat(isWindows()).as("Running on Windows").isFalse();
-
         DumbSlave agent = createDockerContainerAgent(javaDockerRule.get());
         WorkflowJob project = createPipelineOnAgent();
 

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
@@ -4,8 +4,11 @@ import java.util.Collections;
 
 import org.junit.Test;
 
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import hudson.model.FreeStyleProject;
 import hudson.model.Run;
+import jenkins.model.ParameterizedJobMixIn.ParameterizedJob;
 
 import io.jenkins.plugins.coverage.CoveragePublisher;
 import io.jenkins.plugins.coverage.adapter.JacocoReportAdapter;
@@ -22,9 +25,20 @@ public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
 
     private static final String FILE_NAME = "jacoco-analysis-model.xml";
 
+    /** Example integration test for a pipeline with code coverage. */
+    @Test
+    public void coveragePluginPipelineHelloWorld() {
+        WorkflowJob job = createPipelineWithWorkspaceFiles(FILE_NAME);
+        job.setDefinition(new CpsFlowDefinition("node {"
+                + "   publishCoverage adapters: [jacocoAdapter('**/*.xml')]"
+                + "}", true));
+
+        verifySimpleCoverageNode(job);
+    }
+
     /** Example integration test for a freestyle build with code coverage. */
     @Test
-    public void coveragePluginHelloWorld() {
+    public void coveragePluginFreestyleHelloWorld() {
         // automatisch 1. Jenkins starten
         // automatisch 2. Plugin deployen
         // 3a. Job erzeugen
@@ -36,6 +50,10 @@ public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
         coveragePublisher.setAdapters(Collections.singletonList(jacocoReportAdapter));
         project.getPublishersList().add(coveragePublisher);
 
+        verifySimpleCoverageNode(project);
+    }
+
+    private void verifySimpleCoverageNode(final ParameterizedJob<?, ?> project) {
         // 4. Jacoco XML File in den Workspace legen (Stub für einen Build)
         // 5. Jenkins Build starten
         Run<?, ?> build = buildSuccessfully(project);
@@ -46,4 +64,5 @@ public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
         assertThat(coverageResult.getLineCoverage())
                 .isEqualTo(new Coverage(6083, 6368 - 6083));
     }
+
 }

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
@@ -22,6 +22,7 @@ public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
 
     private static final String FILE_NAME = "jacoco-analysis-model.xml";
 
+    /** Example integration test for a freestyle build with code coverage. */
     @Test
     public void coveragePluginHelloWorld() {
         // automatisch 1. Jenkins starten

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
@@ -1,13 +1,27 @@
 package io.jenkins.plugins.coverage.model;
 
+import java.io.IOException;
 import java.util.Collections;
 
+import org.junit.AssumptionViolatedException;
+import org.junit.Rule;
 import org.junit.Test;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.test.acceptance.docker.DockerContainer;
+import org.jenkinsci.test.acceptance.docker.DockerRule;
 import hudson.model.FreeStyleProject;
 import hudson.model.Run;
+import hudson.plugins.sshslaves.SSHLauncher;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.EnvironmentVariablesNodeProperty;
+import hudson.slaves.EnvironmentVariablesNodeProperty.Entry;
 import jenkins.model.ParameterizedJobMixIn.ParameterizedJob;
 
 import io.jenkins.plugins.coverage.CoveragePublisher;
@@ -15,6 +29,7 @@ import io.jenkins.plugins.coverage.adapter.JacocoReportAdapter;
 import io.jenkins.plugins.util.IntegrationTestWithJenkinsPerSuite;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assumptions.*;
 
 /**
  * Integration tests for the coverage API plugin.
@@ -22,6 +37,9 @@ import static org.assertj.core.api.Assertions.*;
  * @author Ullrich Hafner
  */
 public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
+    /** Docker container for java/maven builds. */
+    @Rule
+    public DockerRule<JavaGitContainer> javaDockerRule = new DockerRule<>(JavaGitContainer.class);
 
     private static final String FILE_NAME = "jacoco-analysis-model.xml";
 
@@ -52,6 +70,82 @@ public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
 
         verifySimpleCoverageNode(project);
     }
+
+    @Test
+    public void coverageOnAgent() throws IOException, InterruptedException {
+        assumeThat(isWindows()).as("Running on Windows").isFalse();
+
+        DumbSlave agent = createDockerContainerAgent(javaDockerRule.get());
+        FreeStyleProject project = createFreeStyleProject();
+        project.setAssignedNode(agent);
+
+        copySingleFileToAgentWorkspace(agent, project, FILE_NAME, FILE_NAME);
+        CoveragePublisher coveragePublisher = new CoveragePublisher();
+        JacocoReportAdapter jacocoReportAdapter = new JacocoReportAdapter(FILE_NAME);
+        coveragePublisher.setAdapters(Collections.singletonList(jacocoReportAdapter));
+        project.getPublishersList().add(coveragePublisher);
+
+        verifySimpleCoverageNode(project);
+    }
+
+    @Test
+    public void coverageOnAgentNode() throws IOException, InterruptedException {
+        assumeThat(isWindows()).as("Running on Windows").isFalse();
+
+        DumbSlave agent = createDockerContainerAgent(javaDockerRule.get());
+        WorkflowJob project = createJob();
+
+        copySingleFileToAgentWorkspace(agent, project, FILE_NAME, FILE_NAME);
+
+        verifySimpleCoverageNode(project);
+    }
+
+    private WorkflowJob createJob() {
+        WorkflowJob job = createPipeline();
+        job.setDefinition(new CpsFlowDefinition("node('docker') {"
+                        + "checkout([$class: 'GitSCM', "
+                                + "branches: [[name: '6bd346bbcc9779467ce657b2618ab11e38e28c2c' ]],\n"
+                                + "userRemoteConfigs: [[url: '" + "https://github.com/jenkinsci/analysis-model.git" + "']],\n"
+                                + "extensions: [[$class: 'RelativeTargetDirectory', \n"
+                                + "            relativeTargetDir: 'forensics-api']]])\n"
+                        + "sh 'mvn verify'\n"
+                        + "publishCoverage adapters: [jacocoAdapter('" + FILE_NAME + "')]\n"
+                        + "}", true));
+
+        return job;
+    }
+
+    /**
+     * Creates a docker container agent.
+     *
+     * @param dockerContainer
+     *         The docker container of the agent
+     *
+     * @return A docker container agent.
+     */
+    @SuppressWarnings({"PMD.AvoidCatchingThrowable", "IllegalCatch"})
+    protected DumbSlave createDockerContainerAgent(final DockerContainer dockerContainer) {
+        try {
+            SystemCredentialsProvider.getInstance().getDomainCredentialsMap().put(Domain.global(),
+                    Collections.singletonList(
+                            new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM, "dummyCredentialId",
+                                    null, "test", "test")
+                    )
+            );
+            DumbSlave agent = new DumbSlave("docker", "/home/test",
+                    new SSHLauncher(dockerContainer.ipBound(22), dockerContainer.port(22), "dummyCredentialId"));
+            agent.setNodeProperties(Collections.singletonList(new EnvironmentVariablesNodeProperty(
+                    new Entry("JAVA_HOME", "/usr/lib/jvm/java-8-openjdk-amd64/jre"))));
+            getJenkins().jenkins.addNode(agent);
+            getJenkins().waitOnline(agent);
+
+            return agent;
+        }
+        catch (Throwable e) {
+            throw new AssumptionViolatedException("Failed to create docker container", e);
+        }
+    }
+
 
     private void verifySimpleCoverageNode(final ParameterizedJob<?, ?> project) {
         // 4. Jacoco XML File in den Workspace legen (Stub für einen Build)

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
@@ -48,7 +48,15 @@ public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
     public void coveragePluginPipelineHelloWorld() {
         WorkflowJob job = createPipelineWithWorkspaceFiles(FILE_NAME);
         job.setDefinition(new CpsFlowDefinition("node {"
-                + "   publishCoverage adapters: [jacocoAdapter('**/*.xml')]"
+                + "timestamps {\n"
+                + "    checkout([$class: 'GitSCM', "
+                + "        branches: [[name: '6bd346bbcc9779467ce657b2618ab11e38e28c2c' ]],\n"
+                + "        userRemoteConfigs: [[url: '" + "https://github.com/jenkinsci/analysis-model.git" + "']],\n"
+                + "        extensions: [[$class: 'RelativeTargetDirectory', \n"
+                + "                    relativeTargetDir: 'checkout']]])\n"
+                + "    publishCoverage adapters: [jacocoAdapter('" + FILE_NAME
+                + "')], sourceFileResolver: sourceFiles('STORE_ALL_BUILD')\n"
+                + "}"
                 + "}", true));
 
         verifySimpleCoverageNode(job);
@@ -101,13 +109,16 @@ public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
     private WorkflowJob createPipelineOnAgent() {
         WorkflowJob job = createPipeline();
         job.setDefinition(new CpsFlowDefinition("node('docker') {"
-                        + "    checkout([$class: 'GitSCM', "
-                                + "branches: [[name: '6bd346bbcc9779467ce657b2618ab11e38e28c2c' ]],\n"
-                                + "userRemoteConfigs: [[url: '" + "https://github.com/jenkinsci/analysis-model.git" + "']],\n"
-                                + "extensions: [[$class: 'RelativeTargetDirectory', \n"
-                                + "            relativeTargetDir: 'checkout']]])\n"
-                        + "    publishCoverage adapters: [jacocoAdapter('" + FILE_NAME + "')], sourceFileResolver: sourceFiles('STORE_ALL_BUILD')\n"
-                        + "}", true));
+                + "timestamps {\n"
+                + "    checkout([$class: 'GitSCM', "
+                + "        branches: [[name: '6bd346bbcc9779467ce657b2618ab11e38e28c2c' ]],\n"
+                + "        userRemoteConfigs: [[url: '" + "https://github.com/jenkinsci/analysis-model.git" + "']],\n"
+                + "        extensions: [[$class: 'RelativeTargetDirectory', \n"
+                + "                    relativeTargetDir: 'checkout']]])\n"
+                + "    publishCoverage adapters: [jacocoAdapter('" + FILE_NAME
+                + "')], sourceFileResolver: sourceFiles('STORE_ALL_BUILD')\n"
+                + "}"
+                + "}", true));
 
         return job;
     }

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginITest.java
@@ -1,0 +1,48 @@
+package io.jenkins.plugins.coverage.model;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Run;
+
+import io.jenkins.plugins.coverage.CoveragePublisher;
+import io.jenkins.plugins.coverage.adapter.JacocoReportAdapter;
+import io.jenkins.plugins.util.IntegrationTestWithJenkinsPerSuite;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Integration tests for the coverage API plugin.
+ *
+ * @author Ullrich Hafner
+ */
+public class CoveragePluginITest extends IntegrationTestWithJenkinsPerSuite {
+
+    private static final String FILE_NAME = "jacoco-analysis-model.xml";
+
+    @Test
+    public void coveragePluginHelloWorld() {
+        // automatisch 1. Jenkins starten
+        // automatisch 2. Plugin deployen
+        // 3a. Job erzeugen
+        FreeStyleProject project = createFreeStyleProject();
+        copyFilesToWorkspace(project, FILE_NAME);
+        // 3b. Job konfigurieren// 3a. Job erzeugen
+        CoveragePublisher coveragePublisher = new CoveragePublisher();
+        JacocoReportAdapter jacocoReportAdapter = new JacocoReportAdapter(FILE_NAME);
+        coveragePublisher.setAdapters(Collections.singletonList(jacocoReportAdapter));
+        project.getPublishersList().add(coveragePublisher);
+
+        // 4. Jacoco XML File in den Workspace legen (Stub für einen Build)
+        // 5. Jenkins Build starten
+        Run<?, ?> build = buildSuccessfully(project);
+        // 6. Mit Assertions Ergebnisse überprüfen
+        assertThat(build.getNumber()).isEqualTo(1);
+
+        CoverageBuildAction coverageResult = build.getAction(CoverageBuildAction.class);
+        assertThat(coverageResult.getLineCoverage())
+                .isEqualTo(new Coverage(6083, 6368 - 6083));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoverageXmlStreamTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoverageXmlStreamTest.java
@@ -31,7 +31,7 @@ public class CoverageXmlStreamTest extends SerializableTest<CoverageNode> {
             CoverageResult result = parser.getResult(getResourceAsFile("jacoco-codingstyle.xml").toFile());
             result.stripGroup();
 
-            return CoverageNodeConverter.convert(result);
+            return new CoverageNodeConverter().convert(result);
         }
         catch (CoverageException exception) {
             throw new AssertionError(exception);

--- a/src/test/java/io/jenkins/plugins/coverage/model/JavaGitContainer.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/JavaGitContainer.java
@@ -1,0 +1,11 @@
+package io.jenkins.plugins.coverage.model;
+
+import org.jenkinsci.test.acceptance.docker.DockerFixture;
+import org.jenkinsci.test.acceptance.docker.fixtures.SshdContainer;
+
+@DockerFixture(id = "java-git", ports = {22, 8080}
+)
+public class JavaGitContainer extends SshdContainer {
+    public JavaGitContainer() {
+    }
+}

--- a/src/test/java/io/jenkins/plugins/coverage/model/JavaGitContainer.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/JavaGitContainer.java
@@ -3,9 +3,18 @@ package io.jenkins.plugins.coverage.model;
 import org.jenkinsci.test.acceptance.docker.DockerFixture;
 import org.jenkinsci.test.acceptance.docker.fixtures.SshdContainer;
 
-@DockerFixture(id = "java-git", ports = {22, 8080}
-)
+/**
+ * Represents a server with SSHD, Java tooling, Maven and Git.
+ *
+ * @author Ullrich Hafner
+ */
+@DockerFixture(id = "java-git", ports = {22, 8080})
 public class JavaGitContainer extends SshdContainer {
+    /**
+     * Creates a new instance of {@link JavaGitContainer}.
+     */
     public JavaGitContainer() {
+        super();
+        // required for dependency injection
     }
 }

--- a/src/test/java/io/jenkins/plugins/coverage/model/TreeMapNodeConverterTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/TreeMapNodeConverterTest.java
@@ -4,10 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import edu.hm.hafner.echarts.TreeMapNode;
 
-import io.jenkins.plugins.coverage.CoverageNodeConverter;
-import io.jenkins.plugins.coverage.exception.CoverageException;
-import io.jenkins.plugins.coverage.targets.CoverageResult;
-
 import static org.assertj.core.api.Assertions.*;
 
 /**
@@ -17,10 +13,8 @@ import static org.assertj.core.api.Assertions.*;
  */
 class TreeMapNodeConverterTest extends AbstractCoverageTest {
     @Test
-    void shouldConvertCodingStyleToTree() throws CoverageException {
-        CoverageResult report = readReport("jacoco-codingstyle.xml");
-
-        CoverageNode tree = CoverageNodeConverter.convert(report);
+    void shouldConvertCodingStyleToTree() {
+        CoverageNode tree = readNode("jacoco-codingstyle.xml");
         tree.splitPackages();
 
         TreeMapNode root = new TreeMapNodeConverter().toTeeChartModel(tree);
@@ -36,10 +30,8 @@ class TreeMapNodeConverterTest extends AbstractCoverageTest {
     }
 
     @Test
-    void shouldConvertAnalysisModelToTree() throws CoverageException {
-        CoverageResult report = readReport("jacoco-analysis-model.xml");
-
-        CoverageNode tree = CoverageNodeConverter.convert(report);
+    void shouldConvertAnalysisModelToTree() {
+        CoverageNode tree = readNode("jacoco-analysis-model.xml");
         tree.splitPackages();
 
         TreeMapNode root = new TreeMapNodeConverter().toTeeChartModel(tree);

--- a/src/test/resources/io/jenkins/plugins/coverage/model/JavaGitContainer/Dockerfile
+++ b/src/test/resources/io/jenkins/plugins/coverage/model/JavaGitContainer/Dockerfile
@@ -1,0 +1,16 @@
+#
+# Container for running Java processes
+#
+
+# sha1sum ../SshdContainer/Dockerfile | cut -c 1-12
+FROM jenkins/sshd:32edfdd58111
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        software-properties-common \
+        openjdk-8-jre-headless \
+        openjdk-8-jdk-headless \
+        curl \
+        ant \
+        maven \
+        git


### PR DESCRIPTION
The current approach of painting and archiving source files is very slow and has several flaws.

This new algorithm rewrites this part of the code from scratch.

Here is a sketch of the new algorithm:
- Painting is complete done in a single step on the controller
- Relative paths are automatically determined from the coverage tree structure
- Configurable source path prefix let the callers decide where the source are located
- Painted files are written into a folder in one step (on the agent)
- Painted files folder is zipped and copied in one call from the agent to the controller

Open tasks:
- [ ] Make encoding of source files a parameter of the publisher
- [ ] Make the source path folder(s) a parameter of the publisher
- [ ] Combine scanning for report files, parsings into model and painting of sources in one single step without additional data transfer between controller and agent
- [ ] Use new files in source view
- [ ] Check if we can use prism in source code syntax highlighting 
- [ ] ZIP individual sources as well and decompress on access only
- [ ] Cleanup
- [ ] Tests
