### PR TITLE
Add unit tests that show how to verify the source code view model

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/model/CoverageBuildAction.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/CoverageBuildAction.java
@@ -182,7 +182,7 @@ public class CoverageBuildAction extends BuildAction<CoverageNode> implements He
     }
 
     @Override
-    public Object getTarget() {
+    public CoverageViewModel getTarget() {
         return new CoverageViewModel(getOwner(), getResult());
     }
 

--- a/src/main/java/io/jenkins/plugins/coverage/model/CoverageViewModel.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/CoverageViewModel.java
@@ -164,7 +164,7 @@ public class CoverageViewModel extends DefaultAsyncTableContentProvider implemen
      * @return the new sub-page
      */
     @SuppressWarnings("unused") // Called by jelly view
-    public Object getDynamic(final String link, final StaplerRequest request, final StaplerResponse response) {
+    public SourceViewModel getDynamic(final String link, final StaplerRequest request, final StaplerResponse response) {
         if (StringUtils.isNotEmpty(link)) {
             try {
                 Optional<CoverageNode> targetResult = getNode().findByHashCode(CoverageMetric.FILE, Integer.parseInt(link));

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoverageBuildActionTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoverageBuildActionTest.java
@@ -1,0 +1,30 @@
+package io.jenkins.plugins.coverage.model;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
+
+import hudson.model.Run;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the class {@link CoverageBuildAction}.
+ *
+ * @author Ullrich Hafner
+ */
+class CoverageBuildActionTest {
+    @Test
+    void shouldCreateViewModel() {
+        Run<?, ?> build = mock(Run.class);
+        CoverageNode root = new CoverageNode(CoverageMetric.MODULE, "top-level");
+        SortedMap<CoverageMetric, Double> metrics = new TreeMap<>();
+
+        CoverageBuildAction action = new CoverageBuildAction(build, root, "-", metrics, false);
+
+        assertThat(action.getTarget()).extracting(CoverageViewModel::getNode).isEqualTo(root);
+        assertThat(action.getTarget()).extracting(CoverageViewModel::getOwner).isEqualTo(build);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoverageViewModelTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoverageViewModelTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.*;
 class CoverageViewModelTest extends AbstractCoverageTest {
     @Test
     void shouldReportOverview() {
-        CoverageViewModel model = new CoverageViewModel(mock(Run.class), readNode("jacoco-codingstyle.xml"));
+        CoverageViewModel model = createModel();
 
         assertThat(model.getDisplayName()).contains("Java coding style: jacoco-codingstyle.xml");
 
@@ -32,5 +32,21 @@ class CoverageViewModelTest extends AbstractCoverageTest {
         assertThatJson(overview).node("missed").isArray().containsExactly(
                 0, 3, 3, 5, 29, 90, 7
         );
+
+        assertThat(model.getDynamic("unknown", null, null))
+                .isNull();
+    }
+
+    @Test
+    void shouldReturnEmptySourceViewForExistingLinkButMissingSourceFile() {
+        CoverageViewModel model = createModel();
+
+        String link = String.valueOf("PathUtil.java".hashCode());
+        assertThat(model.getDynamic(link, null, null))
+                .extracting(SourceViewModel::getSourceFileContent).isEqualTo("n/a");
+    }
+
+    private CoverageViewModel createModel() {
+        return new CoverageViewModel(mock(Run.class), readNode("jacoco-codingstyle.xml"));
     }
 }


### PR DESCRIPTION
Add unit tests that show the navigation to the source code view.

Starting with a `CoverageBuildAction` instance, one can navigate to the model of the source code view using the following code snippet:

```
SourceViewModel model = action.getTarget().getDynamic(link, null, null);
```