### PR TITLE
This is a change from Float to BigDecimal to get more precision in th…

### DIFF
--- a/src/main/java/io/jenkins/plugins/coverage/CoverageChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageChecksPublisher.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.coverage;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -116,7 +117,7 @@ class CoverageChecksPublisher {
             float lineCoverage = result.getCoverage(CoverageElement.LINE).getPercentageFloat();
             if (result.getReferenceBuildUrl() != null) {
                 title.append(extractChecksTitle("Line", "target branch", lineCoverage,
-                        result.getCoverageDelta(CoverageElement.LINE)));
+                        result.getCoverageDelta(CoverageElement.LINE).floatValue()));
             } else if (lastRatios.containsKey(CoverageElement.LINE)) {
                 title.append(extractChecksTitle("Line", "last successful build", lineCoverage,
                         lineCoverage - lastRatios.get(CoverageElement.LINE).getPercentageFloat()));
@@ -128,15 +129,13 @@ class CoverageChecksPublisher {
         }
 
         if (result.getCoverage(CoverageElement.CONDITIONAL) != null) {
-            float branchCoverage = result.getCoverage(CoverageElement.CONDITIONAL).getPercentageFloat();
+            BigDecimal branchCoverage = result.getCoverage(CoverageElement.CONDITIONAL).getPercentageBigDecimal();
             if (result.getReferenceBuildUrl() != null) {
-                title.append(extractChecksTitle("Branch", "target branch", branchCoverage,
-                        result.getCoverageDelta(CoverageElement.CONDITIONAL)));
+                title.append(extractChecksTitle("Branch", "target branch", branchCoverage.floatValue(),result.getCoverageDelta(CoverageElement.CONDITIONAL).floatValue()));
             } else if (lastRatios.containsKey(CoverageElement.CONDITIONAL)) {
-                title.append(extractChecksTitle("Branch", "last successful build", branchCoverage,
-                        branchCoverage - lastRatios.get(CoverageElement.CONDITIONAL).getPercentageFloat()));
+                title.append(extractChecksTitle("Branch", "last successful build", branchCoverage.floatValue(), branchCoverage.subtract(lastRatios.get(CoverageElement.CONDITIONAL).getPercentageBigDecimal()).floatValue()));
             } else {
-                title.append(extractChecksTitle("Branch", "", branchCoverage, 0));
+                title.append(extractChecksTitle("Branch", "", branchCoverage.floatValue(), 0));
             }
         }
 

--- a/src/main/java/io/jenkins/plugins/coverage/CoverageNodeConverter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageNodeConverter.java
@@ -48,7 +48,7 @@ public class CoverageNodeConverter {
             for (Map.Entry<CoverageElement, Ratio> coverage : result.getLocalResults().entrySet()) {
                 Ratio ratio = coverage.getValue();
                 CoverageLeaf leaf = new CoverageLeaf(CoverageMetric.valueOf(coverage.getKey().getName()),
-                        new Coverage((int) ratio.numerator, (int) (ratio.denominator - ratio.numerator)));
+                        new Coverage( ratio.numerator.intValue(), (ratio.denominator.subtract(ratio.numerator).intValue())));
                 coverageNode.add(leaf);
             }
             return coverageNode;

--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintStream;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -246,12 +247,12 @@ public class CoverageProcessor {
 
         CoverageResult referenceCoverageResult = referenceAction.getResult();
 
-        Map<CoverageElement, Float> deltaCoverage = new TreeMap<>();
+        Map<CoverageElement, BigDecimal> deltaCoverage = new TreeMap<>();
         referenceCoverageResult.getResults().forEach((coverageElement, referenceRatio) -> {
             Ratio buildRatio = coverageReport.getCoverage(coverageElement);
 
             if (buildRatio != null) {
-                float diff = buildRatio.getPercentageFloat() - referenceRatio.getPercentageFloat();
+                BigDecimal diff = buildRatio.getPercentageBigDecimal().subtract(referenceRatio.getPercentageBigDecimal());
                 listener.getLogger()
                         .println(coverageElement.getName() + " coverage diff: " + diff + "%. Add to CoverageResult.");
                 deltaCoverage.put(coverageElement, diff);
@@ -274,8 +275,8 @@ public class CoverageProcessor {
     }
 
     private void failBuildIfChangeRequestDecreasedCoverage(final CoverageResult coverageResult) throws CoverageException {
-        float coverageDiff = coverageResult.getCoverageDelta(CoverageElement.LINE);
-        if (coverageDiff < 0) {
+        BigDecimal coverageDiff = coverageResult.getCoverageDelta(CoverageElement.LINE);
+        if (coverageDiff.compareTo(BigDecimal.ZERO) < 0) {
             throw new CoverageException(
                     "Fail build because this change request decreases line coverage by " + coverageDiff);
         }

--- a/src/main/java/io/jenkins/plugins/coverage/CoveragePullRequestMonitoringPortlet.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoveragePullRequestMonitoringPortlet.java
@@ -9,6 +9,7 @@ import io.jenkins.plugins.coverage.targets.Ratio;
 import io.jenkins.plugins.monitoring.MonitorPortlet;
 import io.jenkins.plugins.monitoring.MonitorPortletFactory;
 
+import java.math.BigDecimal;
 import java.util.*;
 
 /**
@@ -92,13 +93,13 @@ public class CoveragePullRequestMonitoringPortlet extends MonitorPortlet {
         data.add("covered", covered);
 
         JsonArray missed = new JsonArray();
-        missed.add(line.denominator - line.numerator);
-        missed.add(conditional.denominator - conditional.numerator);
+        missed.add(line.denominator.subtract(line.numerator).floatValue());
+        missed.add(conditional.denominator.subtract(conditional.numerator).floatValue());
         data.add("missed", missed);
 
         JsonArray coveredPercentage = new JsonArray();
-        coveredPercentage.add(line.denominator == 0 ? 0 : (double) (100 * (covered.get(0).getAsInt() / line.denominator)));
-        coveredPercentage.add(conditional.denominator == 0 ? 0 : (double) (100 * (covered.get(1).getAsInt() / conditional.denominator)));
+        coveredPercentage.add(line.denominator.compareTo(BigDecimal.ZERO) == 0 ? 0.00 : (double) (100 * (covered.get(0).getAsInt() / line.denominator.intValue())));
+        coveredPercentage.add(conditional.denominator.compareTo(BigDecimal.ONE) == 0 ? 0 : (double) (100 * (covered.get(1).getAsInt() / conditional.denominator.intValue())));
         data.add("coveredPercentage", coveredPercentage);
 
         JsonArray missedPercentage = new JsonArray();

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageAggregationRule.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageAggregationRule.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.coverage.targets;
 
 
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -15,10 +16,10 @@ public class CoverageAggregationRule {
 
         Ratio prevTotal = result.get(input);
         if (prevTotal == null) {
-            prevTotal = Ratio.create(0, 0);
+            prevTotal = Ratio.create(BigDecimal.ZERO, BigDecimal.ZERO);
         }
 
-        Ratio r = Ratio.create(inputResult.numerator + prevTotal.numerator, inputResult.denominator + prevTotal.denominator);
+        Ratio r = Ratio.create(inputResult.numerator.add(prevTotal.numerator), inputResult.denominator.add(prevTotal.denominator));
         result.put(input, r);
 
         return result;
@@ -26,6 +27,6 @@ public class CoverageAggregationRule {
 
 
     public static Ratio combine(CoverageElement element, Ratio existingResult, Ratio additionalResult) {
-        return Ratio.create(existingResult.numerator + additionalResult.numerator, existingResult.denominator + additionalResult.denominator);
+        return Ratio.create(existingResult.numerator.add( additionalResult.numerator), existingResult.denominator.add(additionalResult.denominator));
     }
 }

--- a/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTreeElement.java
+++ b/src/main/java/io/jenkins/plugins/coverage/targets/CoverageTreeElement.java
@@ -56,11 +56,11 @@ public class CoverageTreeElement implements Serializable {
 
     @Exported
     public float getNumerator() {
-        return ratio.numerator;
+        return ratio.numerator.floatValue();
     }
 
     @Exported
     public float getDenominator() {
-        return ratio.denominator;
+        return ratio.denominator.floatValue();
     }
 }

--- a/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.coverage;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -58,7 +59,7 @@ public class CoverageChecksPublisherTest {
                 .build();
 
         Run build = mock(Run.class);
-        CoverageResult result = createCoverageResult((float)0.6, (float)0.4);
+        CoverageResult result = createCoverageResult( BigDecimal.valueOf(0.6), BigDecimal.valueOf(0.4));
         when(result.getPreviousResult()).thenReturn(null);
         when(result.getOwner()).thenReturn(build);
         when(build.getUrl()).thenReturn(BUILD_LINK);
@@ -197,7 +198,7 @@ public class CoverageChecksPublisherTest {
                         .build())
                 .build();
 
-        CoverageResult result = createCoverageResult((float)0.5, (float)0.3, (float)0.6, (float)0.4, null, 0, -10);
+        CoverageResult result = createCoverageResult(BigDecimal.valueOf(0.5), BigDecimal.valueOf (0.3), BigDecimal.valueOf(0.6),  BigDecimal.valueOf (0.4), null, BigDecimal.ZERO, BigDecimal.valueOf( -10));
         CoverageAction action = new CoverageAction(result);
 
         Localizable localizable = mock(Localizable.class);
@@ -231,7 +232,7 @@ public class CoverageChecksPublisherTest {
                 .build();
 
         Run build = mock(Run.class);
-        CoverageResult result = createCoverageResult((float)0.6, (float)0.4);
+        CoverageResult result = createCoverageResult( BigDecimal.valueOf(0.6) , BigDecimal.valueOf (0.4));
         when(result.getPreviousResult()).thenReturn(null);
         when(result.getOwner()).thenReturn(build);
         when(build.getUrl()).thenReturn(BUILD_LINK);
@@ -285,6 +286,14 @@ public class CoverageChecksPublisherTest {
     private CoverageResult createCoverageResult(final float lastLineCoverage, final float lastConditionCoverage,
             final float lineCoverage, final float conditionCoverage,
             final String targetBuildLink, final float targetLineDiff, final float targetBranchDiff) {
+    	return createCoverageResult( BigDecimal.valueOf(lastLineCoverage), BigDecimal.valueOf(lastConditionCoverage),
+    			BigDecimal.valueOf(lineCoverage), BigDecimal.valueOf(conditionCoverage), targetBuildLink,
+    			BigDecimal.valueOf(targetLineDiff), BigDecimal.valueOf(targetBranchDiff));
+    }
+
+    private CoverageResult createCoverageResult(final BigDecimal lastLineCoverage, final BigDecimal lastConditionCoverage,
+            final BigDecimal lineCoverage, final BigDecimal conditionCoverage,
+            final String targetBuildLink, final BigDecimal targetLineDiff, final BigDecimal targetBranchDiff) {
         Run build = mock(Run.class);
         Run lastBuild = mock(Run.class);
         CoverageResult lastResult = createCoverageResult(lastLineCoverage, lastConditionCoverage);
@@ -302,16 +311,18 @@ public class CoverageChecksPublisherTest {
         return result;
     }
 
-    private CoverageResult createCoverageResult(final float lineCoverage, final float conditionCoverage) {
+
+
+    private CoverageResult createCoverageResult(final BigDecimal lineCoverage, final BigDecimal conditionCoverage) {
         CoverageResult result = mock(CoverageResult.class);
 
         Map<CoverageElement, Ratio> ratios = new HashMap<>(3);
-        ratios.put(CoverageElement.LINE, Ratio.create(lineCoverage, 1));
-        ratios.put(CoverageElement.CONDITIONAL, Ratio.create(conditionCoverage, 1));
+        ratios.put(CoverageElement.LINE, Ratio.create(lineCoverage, BigDecimal.ONE));
+        ratios.put(CoverageElement.CONDITIONAL, Ratio.create(conditionCoverage,  BigDecimal.ONE));
 
         when(result.getResults()).thenReturn(ratios);
-        when(result.getCoverage(CoverageElement.LINE)).thenReturn(Ratio.create(lineCoverage, 1));
-        when(result.getCoverage(CoverageElement.CONDITIONAL)).thenReturn(Ratio.create(conditionCoverage, 1));
+        when(result.getCoverage(CoverageElement.LINE)).thenReturn(Ratio.create(lineCoverage, BigDecimal.ONE));
+        when(result.getCoverage(CoverageElement.CONDITIONAL)).thenReturn(Ratio.create(conditionCoverage,BigDecimal.ONE));
         when(result.getCoverageTrends()).thenReturn(null);
 
         return result;


### PR DESCRIPTION
…73.4 % of coverage

<!-- This is a fix in the type of data to get more precision of the data of coverage->

- [ This is a bugFix Branch 
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ l ] Change the Float to a BigDecimal
- [https://github.com/jenkinsci/code-coverage-api-plugin/issues/191 ]
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ This is a corner case where JUnit won't result in the same result always, so I did not add a new JUnit.] 

<!--
Put an `x` into the [X ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
