### PR TITLE
Improve precision and formatting of percentages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <url>https://github.com/jenkinsci/code-coverage-api-plugin</url>
 
   <properties>
-    <revision>2.0.5</revision>
+    <revision>3.0.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/code-coverage-api-plugin</gitHubRepo>
 
@@ -40,6 +40,7 @@
     <gson.version>2.8.9</gson.version>
     <workflow-cps.version>2.94</workflow-cps.version>
     <workflow-multibranch.version>2.24</workflow-multibranch.version>
+    <streamex.version>0.8.1</streamex.version>
   </properties>
 
   <developers>
@@ -63,7 +64,11 @@
   </licenses>
 
   <dependencies>
-
+    <dependency>
+      <groupId>one.util</groupId>
+      <artifactId>streamex</artifactId>
+      <version>${streamex.version}</version>
+    </dependency>
     <dependency>
       <groupId>net.sf.trove4j</groupId>
       <artifactId>trove4j</artifactId>

--- a/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.math.Fraction;
 
 import com.google.common.collect.Sets;
 
@@ -165,7 +166,7 @@ public class CoverageProcessor {
             Run<?, ?> referenceBuild = possibleReferenceBuild.get();
             CoverageBuildAction previousAction = referenceBuild.getAction(CoverageBuildAction.class);
             if (previousAction != null) {
-                SortedMap<CoverageMetric, Double> delta = coverageNode.computeDelta(previousAction.getResult());
+                SortedMap<CoverageMetric, Fraction> delta = coverageNode.computeDelta(previousAction.getResult());
                 return new CoverageBuildAction(this.run, coverageNode, referenceBuild.getExternalizableId(), delta);
             }
         }

--- a/src/main/java/io/jenkins/plugins/coverage/model/Coverage.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/Coverage.java
@@ -1,6 +1,9 @@
 package io.jenkins.plugins.coverage.model;
 
 import java.io.Serializable;
+import java.util.Locale;
+
+import org.apache.commons.lang3.math.Fraction;
 
 import io.jenkins.plugins.coverage.targets.CoverageElement;
 
@@ -16,7 +19,7 @@ public final class Coverage implements Serializable {
     /** Null object that indicates that the code coverage has not been measured. */
     public static final Coverage NO_COVERAGE = new Coverage(0, 0);
 
-    static final String COVERAGE_NOT_AVAILABLE = "n/a";
+    private static final Fraction HUNDRED = Fraction.getFraction(100, 1);
 
     private final int covered;
     private final int missed;
@@ -44,24 +47,51 @@ public final class Coverage implements Serializable {
     }
 
     /**
-     * Returns the covered percentage in the range of {@code [0, 1]}.
+     * Returns the covered percentage as a {@link Fraction} in the range of {@code [0, 1]}.
      *
      * @return the covered percentage
      */
-    public double getCoveredPercentage() {
+    public Fraction getCoveredPercentage() {
         if (getTotal() == 0) {
-            return 0;
+            return Fraction.ZERO;
         }
-        return covered * 1.0 / getTotal();
+        return Fraction.getFraction(covered, getTotal());
     }
 
     /**
-     * Prints the covered percentage as formatted String (with a precision of two digits after the comma).
+     * Returns the covered percentage as rounded integer value in the range of {@code [0, 100]}.
      *
      * @return the covered percentage
      */
-    public String printCoveredPercentage() {
-        return printPercentage(getCoveredPercentage());
+    // TODO: we should make the charts accept float values
+    public int getRoundedPercentage() {
+        if (getTotal() == 0) {
+            return 0;
+        }
+        return (int) Math.round(getCoveredPercentage().multiplyBy(Coverage.HUNDRED).doubleValue());
+    }
+
+    /**
+     * Formats the covered percentage as String (with a precision of two digits after the comma). Uses
+     * {@code Locale.getDefault()} to format the percentage.
+     *
+     * @return the covered percentage
+     * @see #formatCoveredPercentage(Locale)
+     */
+    public String formatCoveredPercentage() {
+        return formatCoveredPercentage(Locale.getDefault());
+    }
+
+    /**
+     * Formats the covered percentage as String (with a precision of two digits after the comma).
+     *
+     * @param locale
+     *         the locale to use when formatting the percentage
+     *
+     * @return the covered percentage
+     */
+    public String formatCoveredPercentage(final Locale locale) {
+        return printPercentage(locale, getCoveredPercentage());
     }
 
     /**
@@ -74,31 +104,44 @@ public final class Coverage implements Serializable {
     }
 
     /**
-     * Returns the missed percentage in the range of {@code [0, 1]}.
+     * Returns the missed percentage as a {@link Fraction} in the range of {@code [0, 1]}.
      *
      * @return the missed percentage
      */
-    public double getMissedPercentage() {
+    public Fraction getMissedPercentage() {
         if (getTotal() == 0) {
-            return 0;
+            return Fraction.ZERO;
         }
-        return 1 - getCoveredPercentage();
+        return Fraction.ONE.subtract(getCoveredPercentage());
     }
 
     /**
-     * Prints the missed percentage as formatted String (with a precision of two digits after the comma).
+     * Formats the missed percentage as formatted String (with a precision of two digits after the comma). Uses
+     * {@code Locale.getDefault()} to format the percentage.
      *
      * @return the missed percentage
      */
-    public String printMissedPercentage() {
-        return printPercentage(getMissedPercentage());
+    public String formatMissedPercentage() {
+        return formatMissedPercentage(Locale.getDefault());
     }
 
-    private String printPercentage(final double percentage) {
+    /**
+     * Formats the missed percentage as formatted String (with a precision of two digits after the comma).
+     *
+     * @param locale
+     *         the locale to use when formatting the percentage
+     *
+     * @return the missed percentage
+     */
+    public String formatMissedPercentage(final Locale locale) {
+        return printPercentage(locale, getMissedPercentage());
+    }
+
+    private String printPercentage(final Locale locale, final Fraction percentage) {
         if (isSet()) {
-            return String.format("%.2f%%", percentage * 100);
+            return String.format(locale, "%.2f%%", percentage.multiplyBy(HUNDRED).doubleValue());
         }
-        return COVERAGE_NOT_AVAILABLE;
+        return Messages.Coverage_Not_Available();
     }
 
     /**
@@ -118,9 +161,9 @@ public final class Coverage implements Serializable {
     public String toString() {
         int total = getTotal();
         if (total > 0) {
-            return String.format("%.2f (%d/%d)", getCoveredPercentage() * 100, covered, total);
+            return String.format("%s (%s)", formatCoveredPercentage(), getCoveredPercentage());
         }
-        return COVERAGE_NOT_AVAILABLE;
+        return Messages.Coverage_Not_Available();
     }
 
     public int getTotal() {

--- a/src/main/java/io/jenkins/plugins/coverage/model/CoverageLeaf.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/CoverageLeaf.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.coverage.model;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * A leaf in the coverage hierarchy. A leaf is a non-divisible coverage metric like line or branch coverage.
@@ -58,19 +59,12 @@ public final class CoverageLeaf implements Serializable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         CoverageLeaf that = (CoverageLeaf) o;
-
-        if (!metric.equals(that.metric)) {
-            return false;
-        }
-        return coverage.equals(that.coverage);
+        return Objects.equals(metric, that.metric) && Objects.equals(coverage, that.coverage);
     }
 
     @Override
     public int hashCode() {
-        int result = metric.hashCode();
-        result = 31 * result + coverage.hashCode();
-        return result;
+        return Objects.hash(metric, coverage);
     }
 }

--- a/src/main/java/io/jenkins/plugins/coverage/model/CoverageMetric.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/CoverageMetric.java
@@ -139,10 +139,6 @@ public class CoverageMetric implements Comparable<CoverageMetric>, Serializable 
         return name;
     }
 
-    public int getOrder() {
-        return order;
-    }
-
     public boolean isLeaf() {
         return leaf;
     }

--- a/src/main/java/io/jenkins/plugins/coverage/model/CoverageSeriesBuilder.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/CoverageSeriesBuilder.java
@@ -18,13 +18,9 @@ public class CoverageSeriesBuilder extends SeriesBuilder<CoverageBuildAction> {
     protected Map<String, Integer> computeSeries(final CoverageBuildAction coverageBuildAction) {
         Map<String, Integer> series = new HashMap<>();
 
-        series.put(LINE_COVERAGE, asPercentage(coverageBuildAction.getLineCoverage()));
-        series.put(BRANCH_COVERAGE, asPercentage(coverageBuildAction.getBranchCoverage()));
+        series.put(LINE_COVERAGE, coverageBuildAction.getLineCoverage().getRoundedPercentage());
+        series.put(BRANCH_COVERAGE, coverageBuildAction.getBranchCoverage().getRoundedPercentage());
 
         return series;
-    }
-
-    private int asPercentage(final Coverage coverage) {
-        return (int) (coverage.getCoveredPercentage() * 100);
     }
 }

--- a/src/main/java/io/jenkins/plugins/coverage/model/SourceViewModel.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/SourceViewModel.java
@@ -38,7 +38,7 @@ public class SourceViewModel extends CoverageViewModel {
             if (sourceFile != null) {
                 return new TextFile(sourceFile).read();
             }
-            return "n/a";
+            return Messages.Coverage_Not_Available();
         }
         catch (IOException exception) {
             return ExceptionUtils.getStackTrace(exception);

--- a/src/main/java/io/jenkins/plugins/coverage/model/TreeMapNodeConverter.java
+++ b/src/main/java/io/jenkins/plugins/coverage/model/TreeMapNodeConverter.java
@@ -22,7 +22,7 @@ class TreeMapNodeConverter {
         Coverage coverage = node.getCoverage(CoverageMetric.LINE);
 
         TreeMapNode treeNode = new TreeMapNode(node.getName(),
-                assignColor(coverage.getCoveredPercentage() * 100),
+                assignColor(coverage.getRoundedPercentage()),
                 coverage.getTotal(), coverage.getCovered());
         if (node.getMetric().equals(CoverageMetric.FILE)) {
             return treeNode;

--- a/src/main/resources/io/jenkins/plugins/coverage/model/CoverageBuildAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/coverage/model/CoverageBuildAction/summary.jelly
@@ -14,17 +14,17 @@
     </j:choose>
     <ul>
       <j:forEach var="metric" items="${items}">
-        <li>${metric.name}: ${result.getCoverage(metric).printCoveredPercentage()}
+        <li>${metric.name}: ${it.formatCoverage(metric)}
           <j:if test="${it.hasDelta(metric)}">
             <j:choose>
-              <j:when test="${it.getDelta(metric).startsWith('-')}">
+              <j:when test="${it.formatDelta(metric).startsWith('-')}">
                 <j:set var="color" value="#9d1212"/>
               </j:when>
               <j:otherwise>
                 <j:set var="color" value="#0a5f0e"/>
               </j:otherwise>
             </j:choose>
-            <span style="color: ${color}">(${it.getDelta(metric)}%)</span>
+            <span style="color: ${color}">(${it.formatDelta(metric)}%)</span>
           </j:if>
         </li>
       </j:forEach>

--- a/src/main/resources/io/jenkins/plugins/coverage/model/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/coverage/model/Messages.properties
@@ -1,3 +1,5 @@
+Coverage.Not.Available=n/a
+Coverage.Link.Name=Coverage Report
 Coverage.Title=Coverage of ''{0}''
 Table_Column_Package=Package
 Table_Column_File=File

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoverageBuildActionTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoverageBuildActionTest.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.coverage.model;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.apache.commons.lang3.math.Fraction;
 import org.junit.jupiter.api.Test;
 
 import hudson.model.Run;
@@ -20,7 +21,7 @@ class CoverageBuildActionTest {
     void shouldCreateViewModel() {
         Run<?, ?> build = mock(Run.class);
         CoverageNode root = new CoverageNode(CoverageMetric.MODULE, "top-level");
-        SortedMap<CoverageMetric, Double> metrics = new TreeMap<>();
+        SortedMap<CoverageMetric, Fraction> metrics = new TreeMap<>();
 
         CoverageBuildAction action = new CoverageBuildAction(build, root, "-", metrics, false);
 

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoverageLeafTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoverageLeafTest.java
@@ -2,6 +2,8 @@ package io.jenkins.plugins.coverage.model;
 
 import org.junit.jupiter.api.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+
 import static io.jenkins.plugins.coverage.model.Assertions.*;
 
 /**
@@ -16,8 +18,13 @@ class CoverageLeafTest extends AbstractCoverageTest {
     void shouldCreateLeaf() {
         CoverageLeaf coverageLeaf = new CoverageLeaf(LINE, COVERED);
 
-        assertThat(coverageLeaf).hasMetric(LINE).hasToString("[Line]: 100.00 (1/1)");
+        assertThat(coverageLeaf).hasMetric(LINE).hasToString("[Line]: 100.00% (1/1)");
         assertThat(coverageLeaf.getCoverage(LINE)).isEqualTo(COVERED);
         assertThat(coverageLeaf.getCoverage(CoverageMetric.MODULE)).isEqualTo(Coverage.NO_COVERAGE);
+    }
+
+    @Test
+    void shouldObeyEqualsContract() {
+        EqualsVerifier.forClass(CoverageLeaf.class).verify();
     }
 }

--- a/src/test/java/io/jenkins/plugins/coverage/model/CoverageTest.java
+++ b/src/test/java/io/jenkins/plugins/coverage/model/CoverageTest.java
@@ -1,5 +1,9 @@
 package io.jenkins.plugins.coverage.model;
 
+import java.util.Locale;
+
+import org.apache.commons.lang3.math.Fraction;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -12,18 +16,23 @@ import static io.jenkins.plugins.coverage.model.Assertions.*;
  * @author Ullrich Hafner
  */
 class CoverageTest {
-    private static final double PRECISION = 0.01;
+    @BeforeAll
+    static void beforeAll() {
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     @Test
     void shouldProvideNullObject() {
         assertThat(Coverage.NO_COVERAGE).isNotSet()
                 .hasCovered(0)
-                .hasCoveredPercentageCloseTo(0, PRECISION)
+                .hasCoveredPercentage(Fraction.ZERO)
+                .hasRoundedPercentage(0)
                 .hasMissed(0)
-                .hasMissedPercentageCloseTo(0, PRECISION)
-                .hasTotal(0).hasToString(Coverage.COVERAGE_NOT_AVAILABLE);
-        assertThat(Coverage.NO_COVERAGE.printCoveredPercentage()).isEqualTo(Coverage.COVERAGE_NOT_AVAILABLE);
-        assertThat(Coverage.NO_COVERAGE.printMissedPercentage()).isEqualTo(Coverage.COVERAGE_NOT_AVAILABLE);
+                .hasMissedPercentage(Fraction.ZERO)
+                .hasTotal(0)
+                .hasToString(Messages.Coverage_Not_Available());
+        assertThat(Coverage.NO_COVERAGE.formatCoveredPercentage()).isEqualTo(Messages.Coverage_Not_Available());
+        assertThat(Coverage.NO_COVERAGE.formatMissedPercentage()).isEqualTo(Messages.Coverage_Not_Available());
         assertThat(Coverage.NO_COVERAGE.add(Coverage.NO_COVERAGE)).isEqualTo(Coverage.NO_COVERAGE);
     }
 
@@ -32,20 +41,21 @@ class CoverageTest {
         Coverage coverage = new Coverage(6, 4);
         assertThat(coverage).isSet()
                 .hasCovered(6)
-                .hasCoveredPercentageCloseTo(0.60, PRECISION)
+                .hasCoveredPercentage(Fraction.getFraction(6, 10))
+                .hasRoundedPercentage(60)
                 .hasMissed(4)
-                .hasMissedPercentageCloseTo(0.40, PRECISION)
+                .hasMissedPercentage(Fraction.getFraction(4, 10))
                 .hasTotal(10)
-                .hasToString("60.00 (6/10)");
+                .hasToString("60.00% (6/10)");
 
-        assertThat(coverage.printCoveredPercentage()).isEqualTo("60.00%");
-        assertThat(coverage.printMissedPercentage()).isEqualTo("40.00%");
+        assertThat(coverage.formatCoveredPercentage()).isEqualTo("60.00%");
+        assertThat(coverage.formatMissedPercentage()).isEqualTo("40.00%");
 
         assertThat(coverage.add(Coverage.NO_COVERAGE)).isEqualTo(coverage);
         Coverage sum = coverage.add(new Coverage(10, 0));
-        assertThat(sum).isEqualTo(new Coverage(16, 4));
-        assertThat(sum.printCoveredPercentage()).isEqualTo("80.00%");
-        assertThat(sum.printMissedPercentage()).isEqualTo("20.00%");
+        assertThat(sum).isEqualTo(new Coverage(16, 4)).hasRoundedPercentage(80);
+        assertThat(sum.formatCoveredPercentage()).isEqualTo("80.00%");
+        assertThat(sum.formatMissedPercentage()).isEqualTo("20.00%");
     }
 
     @Test


### PR DESCRIPTION
- Use the locale of the browser when formatting percentages.
- Use `Fraction` instances when computing coverages.
- Use `Fraction` instances when computing deltas.

Required to get #289 running on a machine with a non-US locale in Jenkins (e.g. German).
