### PR TITLE
If the coverage decreases on a PR, mark the check as failed

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageAction.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerProxy;
 import hudson.model.Action;
 import hudson.model.HealthReport;
@@ -91,7 +92,9 @@ public class CoverageAction implements StaplerProxy, SimpleBuildStep.LastBuildAc
     }
 
     public void setFailMessage(final String failMessage) {
-        this.failMessage = failMessage;
+        if (StringUtils.isBlank(this.failMessage)) {
+            this.failMessage = failMessage;
+        }
     }
 
     private synchronized void setOwner(final Run<?, ?> owner) {

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import io.jenkins.plugins.coverage.model.Coverage;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -253,9 +252,8 @@ public class CoverageProcessor {
         float coverageDiff = coverageResult.getCoverageDelta(CoverageElement.LINE);
         if (coverageDiff < 0) {
             String message = "Fail build because this change request decreases line coverage by " + coverageDiff;
-            if (StringUtils.isBlank(action.getFailMessage())) {
-                action.setFailMessage(message);
-            }
+            action.setFailMessage(message);
+
             throw new CoverageException(message);
         }
     }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import io.jenkins.plugins.coverage.model.Coverage;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -127,7 +128,7 @@ public class CoverageProcessor {
         action.setHealthReport(healthReport);
 
         if (failBuildIfCoverageDecreasedInChangeRequest) {
-            failBuildIfChangeRequestDecreasedCoverage(coverageReport);
+            failBuildIfChangeRequestDecreasedCoverage(coverageReport, action);
         }
 
         // Transform the old model to the new model
@@ -247,12 +248,15 @@ public class CoverageProcessor {
         return Optional.empty();
     }
 
-    private void failBuildIfChangeRequestDecreasedCoverage(final CoverageResult coverageResult)
+    private void failBuildIfChangeRequestDecreasedCoverage(final CoverageResult coverageResult, final CoverageAction action)
             throws CoverageException {
         float coverageDiff = coverageResult.getCoverageDelta(CoverageElement.LINE);
         if (coverageDiff < 0) {
-            throw new CoverageException(
-                    "Fail build because this change request decreases line coverage by " + coverageDiff);
+            String message = "Fail build because this change request decreases line coverage by " + coverageDiff;
+            if (StringUtils.isBlank(action.getFailMessage())) {
+                action.setFailMessage(message);
+            }
+            throw new CoverageException(message);
         }
     }
 


### PR DESCRIPTION
When `failBuildIfCoverageDecreasedInChangeRequest` is set, as well as failing the build by throwing the exeception this PR adds a failMessage to the action to ensure that when the check is published it is marked as failed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Fixes #256 
