### PR TITLE
Add a coberturaReportAdapter symbol to disambiguate from Cobertura plugin's symbols

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/adapter/CoberturaReportAdapter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/adapter/CoberturaReportAdapter.java
@@ -40,7 +40,7 @@ public final class CoberturaReportAdapter extends JavaXMLCoverageReportAdapter {
         return null;
     }
 
-    @Symbol("cobertura")
+    @Symbol({"cobertura", "coberturaReportAdapter"})
     @Extension
     public static final class CoberturaReportAdapterDescriptor extends JavaCoverageReportAdapterDescriptor
             implements Detectable {


### PR DESCRIPTION
Allows for this report adapter to be disambiguated from the one provided by the Cobertura plugin in the case both plugins are installed; see https://stackoverflow.com/a/72839475/466874 for this specific case and https://issues.jenkins.io/browse/INFRA-2012 and https://github.com/jenkins-infra/helpdesk/issues/1662 for the fundamental issue.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue