### PR TITLE
Use the coverages that are persisted within the action if possible

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>5.29.0</version>
+    <version>5.32.0</version>
     <relativePath />
   </parent>
 

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageBuildAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageBuildAction.java
@@ -366,7 +366,7 @@ public class CoverageBuildAction extends BuildAction<CoverageNode> implements He
     private String formatCoverageForMetric(final CoverageMetric metric,
             final Map<CoverageMetric, CoveragePercentage> coverages) {
         String coverage = Messages.Coverage_Not_Available();
-        if (coverages != null && coverages.containsKey(metric)) {
+        if (coverages.containsKey(metric)) {
             coverage = coverages.get(metric).formatPercentage(Functions.getCurrentLocale());
         }
         return metric.getName() + ": " + coverage;
@@ -492,8 +492,7 @@ public class CoverageBuildAction extends BuildAction<CoverageNode> implements He
      */
     @SuppressWarnings("unused") // Called by jelly view
     public String formatCoverage(final CoverageMetric metric) {
-        String coverage = getResult().printCoverageFor(metric, Functions.getCurrentLocale());
-        return metric.getName() + ": " + coverage;
+        return metric.getName() + ": " + getCoverage(metric).formatCoveredPercentage(Functions.getCurrentLocale());
     }
 
     @Override

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageReporter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageReporter.java
@@ -134,7 +134,8 @@ public class CoverageReporter {
             }
 
             action = new CoverageBuildAction(build, rootNode, healthReport,
-                    referenceAction.getOwner().getExternalizableId(), coverageDelta,
+                    referenceAction.getOwner().getExternalizableId(),
+                    coverageDelta,
                     changeCoverageRoot.getMetricPercentages(),
                     changeCoverageDelta,
                     indirectCoverageChangesTree.getMetricPercentages());

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
@@ -1,12 +1,11 @@
 package io.jenkins.plugins.coverage;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 import org.jvnet.localizer.Localizable;
 import hudson.model.HealthReport;
@@ -25,6 +24,7 @@ import io.jenkins.plugins.util.JenkinsFacade;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@DefaultLocale("en")
 public class CoverageChecksPublisherTest {
     private static final String JENKINS_BASE_URL = "http://127.0.0.1:8080";
     private static final String COVERAGE_URL_NAME = "coverage";
@@ -32,11 +32,6 @@ public class CoverageChecksPublisherTest {
     private static final String TARGET_BUILD_LINK = "job/pipeline-coding-style/job/master/3/";
     private static final String LAST_SUCCESSFUL_BUILD_LINK = "http://127.0.0.1:8080/job/pipeline-coding-style/view/change-requests/job/PR-3/110/";
     private static final String HEALTH_REPORT = "Coverage Healthy score is 100%";
-
-    @BeforeClass
-    public static void enforceEnglishLocale() {
-        Locale.setDefault(Locale.ENGLISH);
-    }
 
     @Test
     public void shouldConstructChecksDetailsWithLineAndMethodCoverage() {

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/AbstractCoverageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/AbstractCoverageTest.java
@@ -1,8 +1,6 @@
 package io.jenkins.plugins.coverage.model;
 
-import java.util.Locale;
-
-import org.junit.jupiter.api.BeforeAll;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 import edu.hm.hafner.util.ResourceTest;
 
@@ -17,6 +15,7 @@ import io.jenkins.plugins.coverage.targets.CoverageResult;
  *
  * @author Ullrich Hafner
  */
+@DefaultLocale("en")
 public abstract class AbstractCoverageTest extends ResourceTest {
     static final CoverageMetric MODULE = CoverageMetric.MODULE;
     static final CoverageMetric PACKAGE = CoverageMetric.PACKAGE;
@@ -26,11 +25,6 @@ public abstract class AbstractCoverageTest extends ResourceTest {
     static final CoverageMetric LINE = CoverageMetric.LINE;
     static final CoverageMetric INSTRUCTION = CoverageMetric.INSTRUCTION;
     static final CoverageMetric BRANCH = CoverageMetric.BRANCH;
-
-    @BeforeAll
-    static void beforeAll() {
-        Locale.setDefault(Locale.ENGLISH);
-    }
 
     /**
      * Reads the {@link CoverageResult} from a coverage report.

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoverageNodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoverageNodeTest.java
@@ -5,8 +5,8 @@ import java.util.Locale;
 import java.util.Optional;
 
 import org.apache.commons.lang3.math.Fraction;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -22,13 +22,9 @@ import static org.mockito.Mockito.*;
  * @author Ullrich Hafner
  * @author Florian Orendi
  */
+@DefaultLocale("en")
 class CoverageNodeTest extends AbstractCoverageTest {
     private static final String PROJECT_NAME = "Java coding style: jacoco-codingstyle.xml";
-
-    @BeforeAll
-    static void beforeAll() {
-        Locale.setDefault(Locale.ENGLISH);
-    }
 
     @Test
     void shouldProvideEmptyPathForDefaultPackage() {

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoverageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoverageTest.java
@@ -1,13 +1,11 @@
 package io.jenkins.plugins.coverage.model;
 
-import java.util.Locale;
-
 import org.apache.commons.lang3.math.Fraction;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -21,12 +19,8 @@ import static io.jenkins.plugins.coverage.model.Coverage.CoverageBuilder.*;
  *
  * @author Ullrich Hafner
  */
+@DefaultLocale("en")
 class CoverageTest {
-    @BeforeAll
-    static void beforeAll() {
-        Locale.setDefault(Locale.ENGLISH);
-    }
-
     @Test
     void shouldProvideNullObject() {
         assertThat(NO_COVERAGE).isNotSet()

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/CoverageColumnTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/CoverageColumnTest.java
@@ -1,11 +1,10 @@
 package io.jenkins.plugins.coverage.model.visualization.dashboard;
 
-import java.util.Locale;
 import java.util.Optional;
 
 import org.apache.commons.lang3.math.Fraction;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 import hudson.Functions;
 import hudson.model.Job;
@@ -28,13 +27,8 @@ import static org.assertj.core.api.Assertions.*;
  *
  * @author Florian Orendi
  */
+@DefaultLocale("en")
 class CoverageColumnTest {
-
-    @BeforeAll
-    static void beforeAll() {
-        Locale.setDefault(Locale.ENGLISH);
-    }
-
     private static final String COLUMN_NAME = "Test Column";
     private static final ProjectCoverage PROJECT_COVERAGE = new ProjectCoverage();
     private static final ProjectCoverageDelta PROJECT_COVERAGE_DELTA = new ProjectCoverageDelta();


### PR DESCRIPTION
Otherwise, the whole coverage result XML will be loaded just for a single value.

Will fix jenkins-infra/helpdesk#3029.
