### PR TITLE
Fix NPE when line number is not present in model

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/targets/CoverageResult.java
@@ -828,7 +828,7 @@ public class CoverageResult implements Serializable, Chartable, ModelObject {
     }
 
     public Set<String> getAdditionalProperty(final String propertyName) {
-        return additionalProperties.get(propertyName);
+        return additionalProperties.getOrDefault(propertyName, Collections.emptySet());
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoverageResultTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoverageResultTest.java
@@ -30,6 +30,13 @@ class CoverageResultTest extends AbstractCoverageTest {
     private static final CoverageElement CLASS_NAME = JavaCoverageReportAdapterDescriptor.CLASS;
 
     @Test
+    void shouldNeverReturnNullForSets() throws CoverageException {
+        CoverageResult project = readReport("jacoco-codingstyle.xml");
+
+        assertThat(project.getAdditionalProperty("not-found")).isEmpty();
+    }
+
+    @Test
     void shouldReadJaCoCoResult() throws CoverageException {
         CoverageResult project = readReport("jacoco-codingstyle.xml");
 


### PR DESCRIPTION
API methods that return a collection should never return `null`.

Fixes https://github.com/jenkinsci/code-coverage-api-plugin/issues/426
