### PR TITLE
Fix coverage URL anchors

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ChangeCoverage.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ChangeCoverage.java
@@ -41,4 +41,9 @@ public class ChangeCoverage extends CoverageColumnType {
     public String formatCoverage(final CoveragePercentage coverage, final Locale locale) {
         return coverage.formatPercentage(locale);
     }
+
+    @Override
+    public String getAnchor() {
+        return "#changeCoverage";
+    }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ChangeCoverageDelta.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ChangeCoverageDelta.java
@@ -41,4 +41,9 @@ public class ChangeCoverageDelta extends CoverageColumnType {
     public String formatCoverage(final CoveragePercentage coverage, final Locale locale) {
         return coverage.formatDeltaPercentage(locale);
     }
+
+    @Override
+    public String getAnchor() {
+        return "#changeCoverage";
+    }
 }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/visualization/dashboard/CoverageColumn.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/visualization/dashboard/CoverageColumn.java
@@ -167,7 +167,7 @@ public class CoverageColumn extends ListViewColumn {
     public String getRelativeCoverageUrl(final Job<?, ?> job) {
         if (hasCoverageAction(job)) {
             CoverageBuildAction action = job.getLastCompletedBuild().getAction(CoverageBuildAction.class);
-            return action.getUrlName();
+            return action.getUrlName() + "/" + selectedCoverageColumnType.getAnchor();
         }
         return "";
     }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/visualization/dashboard/CoverageColumnType.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/visualization/dashboard/CoverageColumnType.java
@@ -81,6 +81,16 @@ public abstract class CoverageColumnType {
     public abstract String formatCoverage(CoveragePercentage coverage, Locale locale);
 
     /**
+     * Returns the anchor which stands for a specific part of the coverage report which belongs to this coverage
+     * column. The default value is '#overview'.
+     *
+     * @return the anchor
+     */
+    public String getAnchor() {
+        return "#overview";
+    }
+
+    /**
      * Gets the names of the available coverage types.
      *
      * @return the display names

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/visualization/dashboard/IndirectCoverageChanges.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/visualization/dashboard/IndirectCoverageChanges.java
@@ -41,4 +41,9 @@ public class IndirectCoverageChanges extends CoverageColumnType {
     public String formatCoverage(final CoveragePercentage coverage, final Locale locale) {
         return coverage.formatPercentage(locale);
     }
+
+    @Override
+    public String getAnchor() {
+        return "#indirectCoverage";
+    }
 }

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/model/CoverageBuildAction/summary.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/model/CoverageBuildAction/summary.jelly
@@ -10,7 +10,7 @@
       <ul>
         <li>
           <b>
-            <a href="coverage/#coverageTree">Project Coverage:</a>
+            <a href="coverage/#lineCoverage">Project Coverage:</a>
           </b>
           <ul>
             <j:forEach var="metric" items="${metrics}">
@@ -39,7 +39,7 @@
           <j:when test="${it.hasChangeCoverage()}">
             <li>
               <b>
-                <a href="coverage/#changeCoverageTree">Change Coverage:</a>
+                <a href="coverage/#changeCoverage">Change Coverage:</a>
               </b>
               <ul>
                 <j:forEach var="metric" items="${metrics}">
@@ -81,7 +81,7 @@
         <j:if test="${it.hasIndirectCoverageChanges()}">
           <li>
             <b>
-              <a href="coverage/#coverageChangesTree">Indirect Coverage Changes:</a>
+              <a href="coverage/#indirectCoverage">Indirect Coverage Changes:</a>
             </b>
             <ul>
               <j:forEach var="metric" items="${metrics}">

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/testutil/CoverageStubs.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/testutil/CoverageStubs.java
@@ -14,6 +14,7 @@ import io.jenkins.plugins.coverage.model.CoverageMetric;
 import io.jenkins.plugins.coverage.model.CoverageNode;
 import io.jenkins.plugins.coverage.model.CoveragePercentage;
 
+import static io.jenkins.plugins.coverage.model.CoverageBuildAction.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -91,6 +92,8 @@ public final class CoverageStubs {
 
         when(action.hasChangeCoverageDifference(coverageMetric)).thenReturn(true);
         when(action.getChangeCoverageDifference(coverageMetric)).thenReturn(percentage);
+
+        when(action.getUrlName()).thenReturn(DETAILS_URL);
 
         return action;
     }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ChangeCoverageDeltaTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ChangeCoverageDeltaTest.java
@@ -46,4 +46,9 @@ class ChangeCoverageDeltaTest extends CoverageColumnTypeTest {
         String formattedCoverage = CHANGE_COVERAGE_DELTA.formatCoverage(COVERAGE_PERCENTAGE, LOCALE);
         assertThat(formattedCoverage).isEqualTo("+50,00%");
     }
+
+    @Test
+    void shouldProvideReportUrl() {
+        assertThat(CHANGE_COVERAGE_DELTA.getAnchor()).isEqualTo("#changeCoverage");
+    }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ChangeCoverageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ChangeCoverageTest.java
@@ -46,4 +46,9 @@ class ChangeCoverageTest extends CoverageColumnTypeTest {
         String formattedCoverage = CHANGE_COVERAGE.formatCoverage(COVERAGE_PERCENTAGE, LOCALE);
         assertThat(formattedCoverage).isEqualTo("50,00%");
     }
+
+    @Test
+    void shouldProvideReportUrl() {
+        assertThat(CHANGE_COVERAGE.getAnchor()).isEqualTo("#changeCoverage");
+    }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/CoverageColumnTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/CoverageColumnTest.java
@@ -47,25 +47,32 @@ class CoverageColumnTest {
     @Test
     void shouldProvideSelectedColumn() {
         CoverageColumn column = createColumn();
+        Job<?, ?> job = createJobWithCoverageAction(Fraction.ZERO);
+
         column.setCoverageType(Messages.Project_Coverage_Type());
         assertThat(column.getCoverageType()).isEqualTo(Messages.Project_Coverage_Type());
         assertThat(column.getSelectedCoverageColumnType()).isInstanceOf(ProjectCoverage.class);
+        assertThat(column.getRelativeCoverageUrl(job)).isEqualTo("coverage/#overview");
 
         column.setCoverageType(Messages.Project_Coverage_Delta_Type());
         assertThat(column.getCoverageType()).isEqualTo(Messages.Project_Coverage_Delta_Type());
         assertThat(column.getSelectedCoverageColumnType()).isInstanceOf(ProjectCoverageDelta.class);
+        assertThat(column.getRelativeCoverageUrl(job)).isEqualTo("coverage/#overview");
 
         column.setCoverageType(Messages.Change_Coverage_Type());
         assertThat(column.getCoverageType()).isEqualTo(Messages.Change_Coverage_Type());
         assertThat(column.getSelectedCoverageColumnType()).isInstanceOf(ChangeCoverage.class);
+        assertThat(column.getRelativeCoverageUrl(job)).isEqualTo("coverage/#changeCoverage");
 
         column.setCoverageType(Messages.Change_Coverage_Delta_Type());
         assertThat(column.getCoverageType()).isEqualTo(Messages.Change_Coverage_Delta_Type());
         assertThat(column.getSelectedCoverageColumnType()).isInstanceOf(ChangeCoverageDelta.class);
+        assertThat(column.getRelativeCoverageUrl(job)).isEqualTo("coverage/#changeCoverage");
 
         column.setCoverageType(Messages.Indirect_Coverage_Changes_Type());
         assertThat(column.getCoverageType()).isEqualTo(Messages.Indirect_Coverage_Changes_Type());
         assertThat(column.getSelectedCoverageColumnType()).isInstanceOf(IndirectCoverageChanges.class);
+        assertThat(column.getRelativeCoverageUrl(job)).isEqualTo("coverage/#indirectCoverage");
     }
 
     @Test

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/IndirectCoverageChangesTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/IndirectCoverageChangesTest.java
@@ -46,4 +46,9 @@ class IndirectCoverageChangesTest extends CoverageColumnTypeTest {
         String formattedCoverage = INDIRECT_COVERAGE_CHANGES.formatCoverage(COVERAGE_PERCENTAGE, LOCALE);
         assertThat(formattedCoverage).isEqualTo("50,00%");
     }
+
+    @Test
+    void shouldProvideReportUrl() {
+        assertThat(INDIRECT_COVERAGE_CHANGES.getAnchor()).isEqualTo("#indirectCoverage");
+    }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ProjectCoverageDeltaTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ProjectCoverageDeltaTest.java
@@ -46,4 +46,9 @@ class ProjectCoverageDeltaTest extends CoverageColumnTypeTest {
         String formattedCoverage = PROJECT_COVERAGE_DELTA.formatCoverage(COVERAGE_PERCENTAGE, LOCALE);
         assertThat(formattedCoverage).isEqualTo("+50,00%");
     }
+
+    @Test
+    void shouldProvideReportUrl() {
+        assertThat(PROJECT_COVERAGE_DELTA.getAnchor()).isEqualTo("#overview");
+    }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ProjectCoverageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/visualization/dashboard/ProjectCoverageTest.java
@@ -46,4 +46,9 @@ class ProjectCoverageTest extends CoverageColumnTypeTest {
         String formattedCoverage = PROJECT_COVERAGE.formatCoverage(COVERAGE_PERCENTAGE, LOCALE);
         assertThat(formattedCoverage).isEqualTo("50,00%");
     }
+
+    @Test
+    void shouldProvideReportUrl() {
+        assertThat(PROJECT_COVERAGE.getAnchor()).isEqualTo("#overview");
+    }
 }


### PR DESCRIPTION
The URL anchors of links in the dashboard column and in the build overview have been fixed. These URLs are now pointing to the corresponding coverage report view in order to simplify the navigation.