### PR TITLE
[#433] Remove duplicate file nodes 

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageNode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageNode.java
@@ -256,6 +256,29 @@ public class CoverageNode implements Serializable {
     }
 
     /**
+     * Removes this node from the coverage tree.
+     */
+    void remove() {
+        // TODO: remove this method when unique paths are handled correctly
+        if (hasParent()) {
+            getParent().getChildren().remove(this);
+            clearEmptyPaths(getParent());
+        }
+    }
+
+    /**
+     * Clears an empty tree path from the bottom of the tree to the top, beginning with the passed node.
+     *
+     * @param node The {@link CoverageNode node} to begin from
+     */
+    private void clearEmptyPaths(final CoverageNode node) {
+        // TODO: remove this method when unique paths are handled correctly
+        if (node != null && node.getChildren().isEmpty()) {
+            node.remove();
+        }
+    }
+
+    /**
      * Returns whether this node is the root of the tree.
      *
      * @return {@code true} if this node is the root of the tree, {@code false} otherwise
@@ -426,21 +449,21 @@ public class CoverageNode implements Serializable {
     }
 
     /**
-     * Finds the coverage metric with the given name starting from this node.
+     * Finds the coverage metric with the given path starting from this node.
      *
      * @param searchMetric
      *         the coverage metric to search for
-     * @param searchName
-     *         the name of the node
+     * @param searchPath
+     *         the path of the node
      *
      * @return the result if found
      */
-    public Optional<CoverageNode> find(final CoverageMetric searchMetric, final String searchName) {
-        if (matches(searchMetric, searchName)) {
+    public Optional<CoverageNode> find(final CoverageMetric searchMetric, final String searchPath) {
+        if (matches(searchMetric, searchPath)) {
             return Optional.of(this);
         }
         return children.stream()
-                .map(child -> child.find(searchMetric, searchName))
+                .map(child -> child.find(searchMetric, searchPath))
                 .flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty))
                 .findAny();
     }
@@ -451,7 +474,7 @@ public class CoverageNode implements Serializable {
      * @param searchMetric
      *         the coverage metric to search for
      * @param searchNameHashCode
-     *         the hash code of the node name
+     *         the hash code of the node path
      *
      * @return the result if found
      */
@@ -470,13 +493,13 @@ public class CoverageNode implements Serializable {
      *
      * @param searchMetric
      *         the coverage metric to search for
-     * @param searchName
+     * @param searchPath
      *         the name of the node
      *
      * @return the result if found
      */
-    public boolean matches(final CoverageMetric searchMetric, final String searchName) {
-        return metric.equals(searchMetric) && name.equals(searchName);
+    private boolean matches(final CoverageMetric searchMetric, final String searchPath) {
+        return metric.equals(searchMetric) && getPath().equals(searchPath);
     }
 
     /**
@@ -489,11 +512,11 @@ public class CoverageNode implements Serializable {
      *
      * @return the result if found
      */
-    public boolean matches(final CoverageMetric searchMetric, final int searchNameHashCode) {
+    private boolean matches(final CoverageMetric searchMetric, final int searchNameHashCode) {
         if (!metric.equals(searchMetric)) {
             return false;
         }
-        return name.hashCode() == searchNameHashCode || getPath().hashCode() == searchNameHashCode;
+        return getPath().hashCode() == searchNameHashCode;
     }
 
     /**

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageNode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageNode.java
@@ -261,7 +261,7 @@ public class CoverageNode implements Serializable {
     void remove() {
         // TODO: remove this method when unique paths are handled correctly
         if (hasParent()) {
-            getParent().getChildren().remove(this);
+            getParent().children.remove(this);
             clearEmptyPaths(getParent());
         }
     }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageTableModel.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageTableModel.java
@@ -157,7 +157,7 @@ class CoverageTableModel extends TableModel {
         }
 
         public String getFileHash() {
-            return String.valueOf(root.getName().hashCode());
+            return String.valueOf(root.getPath().hashCode());
         }
 
         public String getFileName() {
@@ -293,7 +293,7 @@ class CoverageTableModel extends TableModel {
         public String renderFileName(final String fileName, final String path) {
             if (CoverageViewModel.isSourceFileInNewFormatAvailable(buildFolder, resultsId, path)
                     || CoverageViewModel.isSourceFileInOldFormatAvailable(buildFolder, fileName)) {
-                return a().withHref(String.valueOf(fileName.hashCode())).withText(fileName).render();
+                return a().withHref(String.valueOf(path.hashCode())).withText(fileName).render();
             }
             return fileName;
         }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/FilePathValidator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/FilePathValidator.java
@@ -1,0 +1,58 @@
+package io.jenkins.plugins.coverage.model;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import edu.hm.hafner.util.FilteredLog;
+
+import one.util.streamex.StreamEx;
+
+/**
+ * Validates the file paths of the processed project files.
+ *
+ * @author Florian Orendi
+ */
+class FilePathValidator {
+
+    static final String AMBIGUOUS_FILES_MESSAGE =
+            "There are ambiguous file paths which might lead to faulty coverage reports:";
+    static final String REMOVED_MESSAGE =
+            "-> These files have been removed from the report in order to guarantee flawless coverage visualizations";
+    static final String PACKAGE_INFO_MESSAGE =
+            "-> In order to avoid this make sure package names are unique within the whole project";
+
+    /**
+     * Private default constructor.
+     */
+    private FilePathValidator() {
+        // hides the public constructor
+    }
+
+    /**
+     * Verifies that the passed coverage tree only contains files with unique paths. Duplicate paths are logged and
+     * removed from the coverage tree.
+     *
+     * @param root
+     *         The {@link CoverageNode root} of the coverage tree
+     * @param log
+     *         The log
+     */
+    static void verifyPathUniqueness(final CoverageNode root, final FilteredLog log) {
+        List<String> duplicates = StreamEx.of(root.getAllFileCoverageNodes())
+                .map(FileCoverageNode::getPath)
+                .distinct(2)
+                .collect(Collectors.toList());
+        if (!duplicates.isEmpty()) {
+            root.getAllFileCoverageNodes().stream()
+                    .filter(node -> duplicates.contains(node.getPath()))
+                    .forEach(CoverageNode::remove);
+
+            String message = AMBIGUOUS_FILES_MESSAGE + System.lineSeparator()
+                    + String.join("," + System.lineSeparator(), duplicates);
+            log.logError(message);
+            log.logError(REMOVED_MESSAGE);
+            log.logError(PACKAGE_INFO_MESSAGE);
+        }
+    }
+
+}

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoverageNodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoverageNodeTest.java
@@ -222,11 +222,12 @@ class CoverageNodeTest extends AbstractCoverageTest {
         CoverageNode tree = readNode("jacoco-analysis-model.xml");
 
         String checkStyleParser = "CheckStyleParser.java";
-        Optional<CoverageNode> wrappedCheckStyle = tree.find(CoverageMetric.FILE, checkStyleParser);
+        String checkStyleParserPath = "edu/hm/hafner/analysis/parser/checkstyle/" + checkStyleParser;
+        Optional<CoverageNode> wrappedCheckStyle = tree.find(CoverageMetric.FILE, checkStyleParserPath);
         assertThat(wrappedCheckStyle).isNotEmpty().hasValueSatisfying(
                 node -> assertThat(node)
                         .hasName(checkStyleParser)
-                        .hasPath("edu/hm/hafner/analysis/parser/checkstyle/CheckStyleParser.java")
+                        .hasPath(checkStyleParserPath)
         );
 
         CoverageNode checkStyle = wrappedCheckStyle.get();
@@ -246,11 +247,12 @@ class CoverageNodeTest extends AbstractCoverageTest {
                 .containsEntry(BRANCH, Fraction.getFraction(11, 12));
 
         String pmdParser = "PmdParser.java";
-        Optional<CoverageNode> wrappedPmd = tree.find(CoverageMetric.FILE, pmdParser);
+        String pmdParserPath = "edu/hm/hafner/analysis/parser/pmd/" + pmdParser;
+        Optional<CoverageNode> wrappedPmd = tree.find(CoverageMetric.FILE, pmdParserPath);
         assertThat(wrappedPmd).isNotEmpty().hasValueSatisfying(
                 node -> assertThat(node)
                         .hasName(pmdParser)
-                        .hasPath("edu/hm/hafner/analysis/parser/pmd/PmdParser.java")
+                        .hasPath(pmdParserPath)
         );
 
         CoverageNode pmd = wrappedPmd.get();
@@ -358,15 +360,20 @@ class CoverageNodeTest extends AbstractCoverageTest {
         tree.splitPackages();
 
         String fileName = "Ensure.java";
-        assertThat(tree.findByHashCode(FILE, fileName.hashCode())).isNotEmpty().hasValueSatisfying(
-                node -> assertThat(node).hasName(fileName).isNotRoot());
-        assertThat(tree.findByHashCode(PACKAGE, fileName.hashCode())).isEmpty();
+        String filePath = "edu/hm/hafner/util/" + fileName;
+        assertThat(tree.findByHashCode(FILE, filePath.hashCode())).isNotEmpty().hasValueSatisfying(
+                        node -> assertThat(node).hasPath(filePath).isNotRoot());
+        assertThat(tree.findByHashCode(FILE, fileName.hashCode())).isEmpty();
         assertThat(tree.findByHashCode(FILE, "not-found".hashCode())).isEmpty();
 
         String noBranchCoverage = "NoSuchElementException.java";
-        assertThat(tree.find(FILE, noBranchCoverage)).isNotEmpty().hasValueSatisfying(
+        String noBranchCoveragePath = "edu/hm/hafner/util/" + noBranchCoverage;
+        assertThat(tree.find(FILE, noBranchCoveragePath)).isNotEmpty().hasValueSatisfying(
                 node -> {
-                    assertThat(node).hasName(noBranchCoverage).isNotRoot();
+                    assertThat(node)
+                            .hasName(noBranchCoverage)
+                            .hasPath(noBranchCoveragePath)
+                            .isNotRoot();
                     assertThat(node.getCoverage(BRANCH)).isNotSet();
                     assertThat(node.printCoverageFor(BRANCH)).isEqualTo(Messages.Coverage_Not_Available());
                 }
@@ -378,7 +385,8 @@ class CoverageNodeTest extends AbstractCoverageTest {
         CoverageNode tree = readExampleReport();
 
         String fileName = "Ensure.java";
-        assertThat(tree.find(FILE, fileName)).isNotEmpty().hasValueSatisfying(
+        String filePath = "edu/hm/hafner/util/" + fileName;
+        assertThat(tree.find(FILE, filePath)).isNotEmpty().hasValueSatisfying(
                 node -> assertThat(node).hasName(fileName)
                         .hasParentName("edu.hm.hafner.util")
                         .hasParent()
@@ -386,7 +394,7 @@ class CoverageNodeTest extends AbstractCoverageTest {
         );
 
         tree.splitPackages();
-        assertThat(tree.find(FILE, fileName)).isNotEmpty().hasValueSatisfying(
+        assertThat(tree.find(FILE, filePath)).isNotEmpty().hasValueSatisfying(
                 node -> assertThat(node).hasName(fileName)
                         .hasParentName("edu.hm.hafner.util")
                         .hasParent()

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginSourceITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoveragePluginSourceITest.java
@@ -38,6 +38,7 @@ class CoveragePluginSourceITest extends IntegrationTestWithJenkinsPerSuite {
     private static final String SOURCE_FILE_NAME = "AcuCobolParser.java";
     private static final String SOURCE_FILE = SOURCE_FILE_NAME + ".txt";
     private static final String PACKAGE_PATH = "edu/hm/hafner/analysis/parser/";
+    private static final String SOURCE_FILE_PATH = PACKAGE_PATH + SOURCE_FILE_NAME;
     private static final String ACU_COBOL_PARSER_COVERAGE_REPORT = "jacoco-acu-cobol-parser.xml";
     private static final PathUtil PATH_UTIL = new PathUtil();
     static final String FILE_NAME = "jacoco-analysis-model.xml";
@@ -158,7 +159,7 @@ class CoveragePluginSourceITest extends IntegrationTestWithJenkinsPerSuite {
     private void verifySourceCodeInBuild(final Run<?, ?> build, final String sourceCodeSnippet) {
         CoverageViewModel model = verifyViewModel(build);
 
-        assertThat(model.getSourceCode(String.valueOf(SOURCE_FILE_NAME.hashCode()), "coverage-table"))
+        assertThat(model.getSourceCode(String.valueOf(SOURCE_FILE_PATH.hashCode()), "coverage-table"))
                 .contains(sourceCodeSnippet);
     }
 
@@ -167,10 +168,10 @@ class CoveragePluginSourceITest extends IntegrationTestWithJenkinsPerSuite {
         assertThat(action.getLineCoverage())
                 .isEqualTo(new Coverage.CoverageBuilder().setCovered(8).setMissed(0).build());
 
-        Optional<CoverageNode> fileNode = action.getResult().find(CoverageMetric.FILE, SOURCE_FILE_NAME);
+        Optional<CoverageNode> fileNode = action.getResult().find(CoverageMetric.FILE, SOURCE_FILE_PATH);
         assertThat(fileNode).isNotEmpty()
                 .hasValueSatisfying(node ->
-                        assertThat(node.getPath()).isEqualTo(PACKAGE_PATH + SOURCE_FILE_NAME));
+                        assertThat(node.getPath()).isEqualTo(SOURCE_FILE_PATH));
 
         return action.getTarget();
     }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/FileChangesProcessorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/FileChangesProcessorTest.java
@@ -79,7 +79,7 @@ class FileChangesProcessorTest extends AbstractCoverageTest {
         CoverageNode tree = readCoverageTree(TEST_REPORT_AFTER);
         fileChangesProcessor.attachChangedCodeLines(tree, CODE_CHANGES);
 
-        assertThat(tree.findByHashCode(FILE, TEST_FILE_1.hashCode()))
+        assertThat(tree.findByHashCode(FILE, TEST_FILE_1_PATH.hashCode()))
                 .isNotEmpty()
                 .satisfies(node -> {
                     assertThat(node.get()).isInstanceOf(FileCoverageNode.class);
@@ -102,7 +102,7 @@ class FileChangesProcessorTest extends AbstractCoverageTest {
         CoverageNode tree = readCoverageTree(TEST_REPORT_AFTER);
         fileChangesProcessor.attachFileCoverageDeltas(tree, reference, OLD_PATH_MAPPING);
 
-        assertThat(tree.findByHashCode(FILE, TEST_FILE_1.hashCode()))
+        assertThat(tree.findByHashCode(FILE, TEST_FILE_1_PATH.hashCode()))
                 .isNotEmpty()
                 .satisfies(node -> {
                     assertThat(node.get()).isInstanceOf(FileCoverageNode.class);
@@ -139,7 +139,7 @@ class FileChangesProcessorTest extends AbstractCoverageTest {
         CoverageNode tree = readCoverageTree(TEST_REPORT_AFTER);
         fileChangesProcessor.attachIndirectCoveragesChanges(tree, reference, CODE_CHANGES, OLD_PATH_MAPPING);
 
-        assertThat(tree.findByHashCode(FILE, TEST_FILE_1.hashCode()))
+        assertThat(tree.findByHashCode(FILE, TEST_FILE_1_PATH.hashCode()))
                 .isNotEmpty()
                 .satisfies(node -> {
                     assertThat(node.get()).isInstanceOf(FileCoverageNode.class);

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/FilePathValidatorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/FilePathValidatorTest.java
@@ -1,0 +1,91 @@
+package io.jenkins.plugins.coverage.model;
+
+import org.junit.jupiter.api.Test;
+
+import edu.hm.hafner.util.FilteredLog;
+
+import static io.jenkins.plugins.coverage.model.FilePathValidator.*;
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Test class for {@link FilePathValidator}.
+ *
+ * @author Florian Orendi
+ */
+class FilePathValidatorTest extends AbstractCoverageTest {
+
+    @Test
+    void shouldAcceptValidFileStructure() {
+        CoverageNode root = readExampleReport();
+        CoverageNode rootCopy = root.copyTree();
+        FilteredLog log = createLog();
+
+        verifyPathUniqueness(root, log);
+
+        assertThat(root).isEqualTo(rootCopy);
+        assertThat(log.getErrorMessages()).isEmpty();
+    }
+
+    @Test
+    void shouldCorrectInvalidFileStructure() {
+        CoverageNode root = createMultiModuleReportWithDuplicates();
+        FilteredLog log = createLog();
+
+        verifyPathUniqueness(root, log);
+
+        assertThat(root.getAll(CoverageMetric.PACKAGE))
+                .hasSize(1)
+                .satisfies(node -> assertThat(node.get(0).getName()).isEqualTo("package"));
+        assertThat(root.getAll(CoverageMetric.FILE))
+                .hasSize(1)
+                .satisfies(node -> assertThat(node.get(0).getName()).isEqualTo("file2"));
+        assertThat(log.getErrorMessages()).contains(
+                AMBIGUOUS_FILES_MESSAGE + System.lineSeparator() + "package/file",
+                REMOVED_MESSAGE,
+                PACKAGE_INFO_MESSAGE
+        );
+    }
+
+    /**
+     * Creates a {@link FilteredLog log}.
+     *
+     * @return the created log
+     */
+    private FilteredLog createLog() {
+        return new FilteredLog("Log file validations:");
+    }
+
+    /**
+     * Creates a coverage tree for a multi-module project with files with duplicate fully qualified names.
+     *
+     * @return the {@link CoverageNode root} of the tree
+     */
+    private CoverageNode createMultiModuleReportWithDuplicates() {
+        CoverageNode root = new CoverageNode(CoverageMetric.MODULE, "root");
+        CoverageNode module1 = new CoverageNode(CoverageMetric.MODULE, "module1");
+        CoverageNode module2 = new CoverageNode(CoverageMetric.MODULE, "module2");
+        CoverageNode packageName = new PackageCoverageNode("package");
+        CoverageNode packageCopy = packageName.copyEmpty();
+        CoverageNode file = new FileCoverageNode("file", "file");
+        CoverageNode file2 = new FileCoverageNode("file2", "file2");
+        CoverageNode fileCopy = file.copyEmpty();
+        root.add(module1);
+        root.add(module2);
+        module1.add(packageName);
+        module2.add(packageCopy);
+        packageName.add(file);
+        packageName.add(file2);
+        packageCopy.add(fileCopy);
+
+        return root;
+    }
+
+    /**
+     * Reads the coverage tree from the report 'jacoco-codingstyle.xml'.
+     *
+     * @return the {@link CoverageNode} root of the tree
+     */
+    private CoverageNode readExampleReport() {
+        return readNode("jacoco-codingstyle.xml");
+    }
+}


### PR DESCRIPTION
Fixes issue #433:

I inserted a validation of the file structure.
`FileCoverageNodes` which have the same package and file name are removed from the coverage report since at the moment, these files cannot be handled correctly.
These cases will be logged including the name of the affected files.
This can be used as a workaround for the moment to prevent exceptions.
To also cover reference builds, this is executed for the current and the reference coverage tree.

I chose the option to delete ambiguous nodes afterwards, since it also relates to the reference trees, which belongs to older builds, where duplicate paths are also possible at the moment.
And even if I would simply not add files with duplicate paths when creating the tree, there is a possibility that the coverage tree contains empty packages afterwards without file nodes - in my opinion, there shouldn't be empty package nodes.
These methods which remove nodes should be removed when paths are handled as expected.
