### PR TITLE
Fix for #449 - Enhanced tree map visualization

### DIFF
--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/model/CoverageViewModel/index.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/model/CoverageViewModel/index.jelly
@@ -3,7 +3,7 @@
 
   <st:header name="Content-Type" value="text/html;charset=UTF-8"/>
 
-  <bs:page it="${it}" class="fluid-container d-flex flex-column">
+  <bs:page it="${it}" class="fluid-container d-flex flex-column h-100">
 
     <st:adjunct includes="io.jenkins.plugins.echarts"/>
     <st:adjunct includes="io.jenkins.plugins.data-tables-select"/>
@@ -42,35 +42,34 @@
       </j:if>
     </ul>
 
-    <div class="tab-content">
+    <div class="tab-content h-100">
 
-      <div role="tabpanel" id="overview" class="tab-pane fade">
+      <div role="tabpanel" id="overview" class="tab-pane fade h-100">
+
         <div class="row">
-
           <div class="col-5">
             <bs:card title="${%Total coverage overview}" fontAwesomeIcon="chart-bar">
-              <div id="coverage-overview" class="graph-cursor-pointer overview-chart h-100"/>
+              <div id="coverage-overview" class="graph-cursor-pointer overview-chart"/>
             </bs:card>
           </div>
-
           <div class="col-7">
             <bs:card title="${%Coverage trend}" fontAwesomeIcon="chart-line">
-              <div id="coverage-trend" class="graph-cursor-pointer overview-chart h-100"/>
+              <div id="coverage-trend" class="graph-cursor-pointer overview-chart"/>
             </bs:card>
           </div>
-
         </div>
       </div>
 
-      <div role="tabpanel" id="lineCoverage" class="tab-pane fade">
-        <bs:card title="${%Line coverage}" fontAwesomeIcon="folder-tree">
-          <div id="project-line-coverage" class="graph-cursor-pointer tree-chart"/>
+      <div role="tabpanel" id="lineCoverage" class="tab-pane fade h-100">
+        <bs:card title="${%Line coverage}" fontAwesomeIcon="folder-tree"
+                 class="flex-fill h-100" bodyClass="d-flex flex-column h-100">
+          <div id="project-line-coverage" class="graph-cursor-pointer tree-chart flex-grow-1"/>
         </bs:card>
       </div>
-
-      <div role="tabpanel" id="branchCoverage" class="tab-pane fade">
-        <bs:card title="${%Branch coverage}" fontAwesomeIcon="folder-tree" >
-          <div id="project-branch-coverage" class="graph-cursor-pointer tree-chart"/>
+      <div role="tabpanel" id="branchCoverage" class="tab-pane fade h-100">
+        <bs:card title="${%Branch coverage}" fontAwesomeIcon="folder-tree"
+                 class="flex-fill h-100" bodyClass="d-flex flex-column h-100">
+          <div id="project-branch-coverage" class="graph-cursor-pointer tree-chart flex-grow-1"/>
         </bs:card>
       </div>
 

--- a/plugin/src/main/webapp/js/charts.js
+++ b/plugin/src/main/webapp/js/charts.js
@@ -168,63 +168,63 @@ const CoverageChartGenerator = function ($) {
                     itemStyle: {
                         borderColor: '#ddd',
                         borderWidth: 2,
-                        gapWidth: 2
+                        gapWidth: 3
                     }
                 },
                 {
                     itemStyle: {
                         borderWidth: 4,
-                        gapWidth: 2,
-                        borderColorSaturation: 0.6
+                        gapWidth: 5,
+                        borderColorSaturation: 0.2
                     }
                 },
                 {
                     itemStyle: {
                         borderWidth: 4,
-                        gapWidth: 2,
-                        borderColorSaturation: 0.7
+                        gapWidth: 3,
+                        borderColorSaturation: 0.8
                     }
                 },
                 {
                     itemStyle: {
                         borderWidth: 4,
-                        gapWidth: 2,
-                        borderColorSaturation: 0.6
+                        gapWidth: 3,
+                        borderColorSaturation: 0.2
                     }
                 },
                 {
                     itemStyle: {
                         borderWidth: 4,
-                        gapWidth: 2,
-                        borderColorSaturation: 0.7
+                        gapWidth: 3,
+                        borderColorSaturation: 0.8
                     }
                 },
                 {
                     itemStyle: {
                         borderWidth: 4,
-                        gapWidth: 2,
-                        borderColorSaturation: 0.6
+                        gapWidth: 3,
+                        borderColorSaturation: 0.2
                     }
                 },
                 {
                     itemStyle: {
                         borderWidth: 4,
-                        gapWidth: 2,
-                        borderColorSaturation: 0.7
+                        gapWidth: 3,
+                        borderColorSaturation: 0.8
                     }
                 },
                 {
                     itemStyle: {
                         borderWidth: 4,
-                        gapWidth: 2,
-                        borderColorSaturation: 0.6
+                        gapWidth: 3,
+                        borderColorSaturation: 0.2
                     }
                 },
                 {
                     itemStyle: {
                         borderWidth: 4,
-                        gapWidth: 2,
-                        borderColorSaturation: 0.7
+                        gapWidth: 3,
+                        borderColorSaturation: 0.8
                     }
                 },
             ];


### PR DESCRIPTION
In order to make the tree map easier to read, I changed the following:

- the tree map is shown on the whole screen now 
- the border color saturation is alternating, following the [echarts documentation](https://echarts.apache.org/en/option.html#series-treemap.itemStyle.borderColorSaturation), which says that an alternating high color saturation is a good option for distinguishing different sections.