### PR TITLE
Prevent mismatches between code delta and jacoco data - Issue #467

### DIFF
--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CodeDeltaCalculatorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CodeDeltaCalculatorTest.java
@@ -144,6 +144,26 @@ class CodeDeltaCalculatorTest {
                 .containsExactlyInAnyOrderEntriesOf(should);
     }
 
+    // checks the functionality to prevent exceptions in case of false calculated code deltas
+    @Test
+    void shouldNotCreateOldPathMappingWithCodeDeltaMismatches() {
+        CodeDeltaCalculator codeDeltaCalculator = createCodeDeltaCalculator();
+        FilteredLog log = createFilteredLog();
+        CoverageNode tree = createMockedCoverageTree();
+        CoverageNode referenceTree = createMockedReferenceCoverageTree();
+
+        // two changes with the same former path
+        Map<String, FileChanges> changes = new HashMap<>();
+        changes.put(REPORT_PATH_RENAME, createFileChanges(SCM_PATH_RENAME, OLD_SCM_PATH_RENAME, FileEditType.RENAME));
+        changes.put(REPORT_PATH_MODIFY, createFileChanges(REPORT_PATH_MODIFY, OLD_SCM_PATH_RENAME, FileEditType.RENAME));
+
+        assertThatThrownBy(() -> codeDeltaCalculator.createOldPathMapping(tree, referenceTree, changes, log))
+                .isInstanceOf(CodeDeltaException.class)
+                .hasMessageStartingWith(CODE_DELTA_TO_COVERAGE_DATA_MISMATCH_ERROR_TEMPLATE)
+                .hasMessageContainingAll("new: 'example\\Test_Renamed.java' - former: 'example\\Test.java',",
+                        "new: 'example\\test\\Test.java' - former: 'example\\Test.java'");
+    }
+
     /**
      * Creates an instance of {@link CodeDeltaCalculator}.
      *

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CodeDeltaCalculatorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CodeDeltaCalculatorTest.java
@@ -10,9 +10,12 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.file.PathUtils;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
 
 import edu.hm.hafner.util.FilteredLog;
+import edu.hm.hafner.util.PathUtil;
 
 import hudson.FilePath;
 import hudson.model.Run;
@@ -160,8 +163,9 @@ class CodeDeltaCalculatorTest {
         assertThatThrownBy(() -> codeDeltaCalculator.createOldPathMapping(tree, referenceTree, changes, log))
                 .isInstanceOf(CodeDeltaException.class)
                 .hasMessageStartingWith(CODE_DELTA_TO_COVERAGE_DATA_MISMATCH_ERROR_TEMPLATE)
-                .hasMessageContainingAll("new: 'example\\Test_Renamed.java' - former: 'example\\Test.java',",
-                        "new: 'example\\test\\Test.java' - former: 'example\\Test.java'");
+                .hasMessageContainingAll(
+                        String.format("new: '%s' - former: '%s',", REPORT_PATH_RENAME, OLD_REPORT_PATH_RENAME),
+                        String.format("new: '%s' - former: '%s'", REPORT_PATH_MODIFY, OLD_REPORT_PATH_RENAME));
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CodeDeltaCalculatorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CodeDeltaCalculatorTest.java
@@ -10,12 +10,9 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.commons.io.file.PathUtils;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
 
 import edu.hm.hafner.util.FilteredLog;
-import edu.hm.hafner.util.PathUtil;
 
 import hudson.FilePath;
 import hudson.model.Run;


### PR DESCRIPTION
I added an additional check to prevent exception in case of mismatches between the calculated code delta and the Jacoco coverage data.
This prevents the bug from issue #467.
After an unexpected behavior has been detected, all caluclations based on the code delta are skipped and the error is logged.

