### PR TITLE
#487 - Skip missing reference files when creating coverage delta

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/FileChangesProcessor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/FileChangesProcessor.java
@@ -82,8 +82,9 @@ public class FileChangesProcessor {
             final Map<String, String> oldPathMapping) {
         Map<String, FileCoverageNode> fileNodes = getFileNodeMappingWithReferencePaths(root, oldPathMapping);
         Map<String, FileCoverageNode> referenceFileNodes = getReferenceFileNodeMapping(fileNodes, referenceNode);
-        fileNodes.forEach(
-                (referencePath, node) -> attachFileCoverageDelta(node, referenceFileNodes.get(referencePath)));
+        fileNodes.entrySet().stream()
+                .filter(entry -> referenceFileNodes.containsKey(entry.getKey()))
+                .forEach(entry -> attachFileCoverageDelta(entry.getValue(), referenceFileNodes.get(entry.getKey())));
     }
 
     /**

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CodeDeltaCalculatorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CodeDeltaCalculatorTest.java
@@ -155,7 +155,6 @@ class CodeDeltaCalculatorTest {
         changes.put(REPORT_PATH_RENAME, createFileChanges(SCM_PATH_RENAME, OLD_SCM_PATH_RENAME, FileEditType.RENAME));
 
         assertThat(codeDeltaCalculator.createOldPathMapping(tree, referenceTree, changes, log)).isEmpty();
-        System.out.println(log.getInfoMessages());
         assertThat(log.getInfoMessages()).contains(
                 EMPTY_OLD_PATHS_WARNING + System.lineSeparator() + REPORT_PATH_RENAME
         );

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CodeDeltaCalculatorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CodeDeltaCalculatorTest.java
@@ -144,6 +144,23 @@ class CodeDeltaCalculatorTest {
                 .containsExactlyInAnyOrderEntriesOf(should);
     }
 
+    @Test
+    void shouldNotCreateOldPathMappingWithMissingReferenceNodes() throws CodeDeltaException {
+        CodeDeltaCalculator codeDeltaCalculator = createCodeDeltaCalculator();
+        FilteredLog log = createFilteredLog();
+
+        CoverageNode tree = new CoverageNode(CoverageMetric.FILE, REPORT_PATH_RENAME);
+        CoverageNode referenceTree = new CoverageNode(CoverageMetric.FILE, REPORT_PATH_MODIFY);
+        Map<String, FileChanges> changes = new HashMap<>();
+        changes.put(REPORT_PATH_RENAME, createFileChanges(SCM_PATH_RENAME, OLD_SCM_PATH_RENAME, FileEditType.RENAME));
+
+        assertThat(codeDeltaCalculator.createOldPathMapping(tree, referenceTree, changes, log)).isEmpty();
+        System.out.println(log.getInfoMessages());
+        assertThat(log.getInfoMessages()).contains(
+                EMPTY_OLD_PATHS_WARNING + System.lineSeparator() + REPORT_PATH_RENAME
+        );
+    }
+
     /**
      * Creates an instance of {@link CodeDeltaCalculator}.
      *


### PR DESCRIPTION
Fix for issue #487 .
Missing reference files will be ignored when processing the coverage deltas.
Ignored files are logged.

I also added tests to ensure the fix worked.
