### PR TITLE
[#204] - Add SCM `checksName` parameter

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageChecksPublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageChecksPublisher.java
@@ -38,15 +38,17 @@ class CoverageChecksPublisher {
     private final JenkinsFacade jenkinsFacade;
     private static final List<String> COVERAGE_TYPES =
             Arrays.asList("Report", "Group", "Package", "File", "Class", "Method", "Conditional", "Line", "Instruction");
+    private final String checksName;
 
-    CoverageChecksPublisher(final CoverageAction action) {
-        this(action, new JenkinsFacade());
+    CoverageChecksPublisher(final CoverageAction action, final String checksName) {
+        this(action, new JenkinsFacade(), checksName);
     }
 
     @VisibleForTesting
-    CoverageChecksPublisher(final CoverageAction action, final JenkinsFacade jenkinsFacade) {
+    CoverageChecksPublisher(final CoverageAction action, final JenkinsFacade jenkinsFacade, final String checksName) {
         this.jenkinsFacade = jenkinsFacade;
         this.action = action;
+        this.checksName = checksName;
     }
 
     void publishChecks(final TaskListener listener) {
@@ -64,7 +66,7 @@ class CoverageChecksPublisher {
                 .build();
 
         return new ChecksDetailsBuilder()
-                .withName("Code Coverage")
+                .withName(checksName)
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(StringUtils.isBlank(action.getFailMessage()) ? ChecksConclusion.SUCCESS : ChecksConclusion.FAILURE)
                 .withDetailsURL(jenkinsFacade.getAbsoluteUrl(result.getOwner().getUrl(), action.getUrlName()))

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoveragePublisher.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoveragePublisher.java
@@ -75,6 +75,8 @@ public class CoveragePublisher extends Recorder implements SimpleBuildStep {
 
     private boolean skipPublishingChecks = false;
 
+    private String checksName = "Code Coverage";
+
     @DataBoundConstructor
     public CoveragePublisher() {
     }
@@ -123,7 +125,7 @@ public class CoveragePublisher extends Recorder implements SimpleBuildStep {
         if (!skipPublishingChecks) {
             CoverageAction coverageAction = run.getAction(CoverageAction.class);
             if (coverageAction != null) {
-                CoverageChecksPublisher checksPublisher = new CoverageChecksPublisher(coverageAction);
+                CoverageChecksPublisher checksPublisher = new CoverageChecksPublisher(coverageAction, checksName);
                 checksPublisher.publishChecks(listener);
             }
         }
@@ -245,6 +247,15 @@ public class CoveragePublisher extends Recorder implements SimpleBuildStep {
 
     public boolean isSkipPublishingChecks() {
         return skipPublishingChecks;
+    }
+
+    public String getChecksName() {
+        return checksName;
+    }
+
+    @DataBoundSetter
+    public void setChecksName(final String checksName) {
+        this.checksName = checksName;
     }
 
     @DataBoundSetter

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/CoveragePublisher/config.jelly
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/CoveragePublisher/config.jelly
@@ -25,6 +25,9 @@
     <f:entry title="Disable Publish Checks" field="skipPublishingChecks">
       <f:checkbox/>
     </f:entry>
+    <f:entry title="SCM Check Name" field="checksName">
+        <f:textbox />
+    </f:entry>
     <f:entry title="${%Global Thresholds}">
       <f:repeatableProperty field="globalThresholds">
       </f:repeatableProperty>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/CoveragePublisher/help-checksName.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/CoveragePublisher/help-checksName.html
@@ -1,0 +1,4 @@
+<div>
+    If provided, and publishing checks enabled, the plugin will use this name when publishing results to corresponding
+    SCM hosting platforms. If not, the default of "Code Coverage" will be used.
+</div>

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
@@ -32,6 +32,7 @@ public class CoverageChecksPublisherTest {
     private static final String TARGET_BUILD_LINK = "job/pipeline-coding-style/job/master/3/";
     private static final String LAST_SUCCESSFUL_BUILD_LINK = "http://127.0.0.1:8080/job/pipeline-coding-style/view/change-requests/job/PR-3/110/";
     private static final String HEALTH_REPORT = "Coverage Healthy score is 100%";
+    private static final String CHECKS_NAME = "Code Coverage";
 
     @BeforeClass
     public static void enforceEnglishLocale() {
@@ -41,7 +42,7 @@ public class CoverageChecksPublisherTest {
     @Test
     public void shouldConstructChecksDetailsWithLineAndMethodCoverage() {
         ChecksDetails expectedDetails = new ChecksDetailsBuilder()
-                .withName("Code Coverage")
+                .withName(CHECKS_NAME)
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(ChecksConclusion.SUCCESS)
                 .withDetailsURL(JENKINS_BASE_URL + "/" + BUILD_LINK + COVERAGE_URL_NAME)
@@ -64,7 +65,7 @@ public class CoverageChecksPublisherTest {
         when(build.getUrl()).thenReturn(BUILD_LINK);
         when(build.getPreviousSuccessfulBuild()).thenReturn(null);
 
-        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins())
+        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins(), CHECKS_NAME)
                 .extractChecksDetails())
                 .usingRecursiveComparison()
                 .isEqualTo(expectedDetails);
@@ -73,7 +74,7 @@ public class CoverageChecksPublisherTest {
     @Test
     public void shouldConstructChecksDetailsWithIncreasedLineCoverageAndConditionalCoverage() {
         ChecksDetails expectedDetails = new ChecksDetailsBuilder()
-                .withName("Code Coverage")
+                .withName(CHECKS_NAME)
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(ChecksConclusion.SUCCESS)
                 .withDetailsURL(JENKINS_BASE_URL + "/" + BUILD_LINK + COVERAGE_URL_NAME)
@@ -100,7 +101,7 @@ public class CoverageChecksPublisherTest {
         when(localizable.toString()).thenReturn(HEALTH_REPORT);
         action.setHealthReport(new HealthReport(100, localizable));
 
-        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins())
+        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins(), CHECKS_NAME)
                 .extractChecksDetails())
                 .usingRecursiveComparison()
                 .isEqualTo(expectedDetails);
@@ -109,7 +110,7 @@ public class CoverageChecksPublisherTest {
     @Test
     public void shouldConstructChecksDetailsWithDecreasedLineCoverageAndConditionalCoverage() {
         ChecksDetails expectedDetails = new ChecksDetailsBuilder()
-                .withName("Code Coverage")
+                .withName(CHECKS_NAME)
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(ChecksConclusion.SUCCESS)
                 .withDetailsURL(JENKINS_BASE_URL + "/job/pipeline-coding-style/job/PR-3/49/coverage")
@@ -136,7 +137,7 @@ public class CoverageChecksPublisherTest {
         when(localizable.toString()).thenReturn(HEALTH_REPORT);
         action.setHealthReport(new HealthReport(100, localizable));
 
-        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins())
+        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins(), CHECKS_NAME)
                 .extractChecksDetails())
                 .usingRecursiveComparison()
                 .isEqualTo(expectedDetails);
@@ -145,7 +146,7 @@ public class CoverageChecksPublisherTest {
     @Test
     public void shouldConstructChecksDetailsWithUnchangedLineAndConditionalCoverage() {
         ChecksDetails expectedDetails = new ChecksDetailsBuilder()
-                .withName("Code Coverage")
+                .withName(CHECKS_NAME)
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(ChecksConclusion.SUCCESS)
                 .withDetailsURL(JENKINS_BASE_URL + "/job/pipeline-coding-style/job/PR-3/49/coverage")
@@ -170,7 +171,7 @@ public class CoverageChecksPublisherTest {
         when(localizable.toString()).thenReturn(HEALTH_REPORT);
         action.setHealthReport(new HealthReport(100, localizable));
 
-        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins())
+        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins(), CHECKS_NAME)
                 .extractChecksDetails())
                 .usingRecursiveComparison()
                 .isEqualTo(expectedDetails);
@@ -179,7 +180,7 @@ public class CoverageChecksPublisherTest {
     @Test
     public void shouldUseLastSuccessfulBuildForLineCoverageIfNoTargetBranchIsComparedWith() {
         ChecksDetails expectedDetails = new ChecksDetailsBuilder()
-                .withName("Code Coverage")
+                .withName(CHECKS_NAME)
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(ChecksConclusion.SUCCESS)
                 .withDetailsURL(JENKINS_BASE_URL + "/job/pipeline-coding-style/job/PR-3/49/coverage")
@@ -204,7 +205,7 @@ public class CoverageChecksPublisherTest {
         when(localizable.toString()).thenReturn(HEALTH_REPORT);
         action.setHealthReport(new HealthReport(100, localizable));
 
-        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins())
+        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins(), CHECKS_NAME)
                 .extractChecksDetails())
                 .usingRecursiveComparison()
                 .isEqualTo(expectedDetails);
@@ -213,7 +214,7 @@ public class CoverageChecksPublisherTest {
     @Test
     public void shouldPublishFailedCheck() {
         ChecksDetails expectedDetails = new ChecksDetailsBuilder()
-                .withName("Code Coverage")
+                .withName(CHECKS_NAME)
                 .withStatus(ChecksStatus.COMPLETED)
                 .withConclusion(ChecksConclusion.FAILURE)
                 .withDetailsURL(JENKINS_BASE_URL + "/" + BUILD_LINK + COVERAGE_URL_NAME)
@@ -244,7 +245,7 @@ public class CoverageChecksPublisherTest {
         action.setHealthReport(new HealthReport(100, localizable));
         action.setFailMessage("Failed because coverage is unhealthy.");
 
-        assertThat(new CoverageChecksPublisher(action, createJenkins())
+        assertThat(new CoverageChecksPublisher(action, createJenkins(), CHECKS_NAME)
                 .extractChecksDetails())
                 .usingRecursiveComparison()
                 .isEqualTo(expectedDetails);
@@ -275,7 +276,7 @@ public class CoverageChecksPublisherTest {
         when(localizable.toString()).thenReturn(HEALTH_REPORT);
         action.setHealthReport(new HealthReport(100, localizable));
 
-        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins())
+        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins(), CHECKS_NAME)
                 .extractChecksDetails().getOutput())
                 .isPresent()
                 .get()

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageChecksPublisherTest.java
@@ -251,6 +251,21 @@ public class CoverageChecksPublisherTest {
                 .isEqualTo(expectedDetails);
     }
 
+    @Test
+    public void shouldPublishCheckName() {
+        Run build = mock(Run.class);
+        CoverageResult result = mock(CoverageResult.class);
+        when(result.getOwner()).thenReturn(build);
+        when(build.getUrl()).thenReturn(BUILD_LINK);
+
+        String checksName = "Custom Checks Name";
+        assertThat(new CoverageChecksPublisher(createActionWithDefaultHealthReport(result), createJenkins(), checksName)
+                .extractChecksDetails().getName())
+                .isPresent()
+                .get()
+                .isEqualTo(checksName);
+    }
+
     private CoverageAction getCoverageAction(final CoverageResult result) {
         CoverageAction action = new CoverageAction(result);
         action.onAttached(mock(Run.class));

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/ChecksNameITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/ChecksNameITest.java
@@ -1,0 +1,157 @@
+package io.jenkins.plugins.coverage.model;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.jvnet.hudson.test.TestExtension;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import hudson.ExtensionList;
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+import io.jenkins.plugins.checks.api.ChecksDetails;
+import io.jenkins.plugins.checks.api.ChecksPublisher;
+import io.jenkins.plugins.checks.api.ChecksPublisherFactory;
+import io.jenkins.plugins.coverage.CoveragePublisher;
+import io.jenkins.plugins.coverage.adapter.JacocoReportAdapter;
+import io.jenkins.plugins.util.IntegrationTestWithJenkinsPerSuite;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests setting of SCM checks name.
+ */
+class ChecksNameITest extends IntegrationTestWithJenkinsPerSuite {
+    private static final String JACOCO_FILENAME = "jacoco-analysis-model.xml";
+    private static final String DEFAULT_CHECKS_NAME = "Code Coverage";
+
+    @ParameterizedTest(name = "{index} => checksName={0}")
+    @NullSource
+    @ValueSource(strings = {"Custom Checks Name", ""})
+    void freeStylePublishingOfChecks(final String checksName) {
+        FreeStyleProject project = getFreeStyleProject(checksName);
+        assertSuccessfulBuild(buildSuccessfully(project));
+        checkPublisherDetails(checksName);
+    }
+
+    @ParameterizedTest(name = "{index} => checksName={0}")
+    @NullSource
+    @ValueSource(strings = {"Custom Checks Name", ""})
+    void pipelinePublishingOfCheckName(final String checksName) {
+        WorkflowJob job = getPipelineProject(checksName);
+        assertSuccessfulBuild(buildSuccessfully(job));
+        checkPublisherDetails(checksName);
+    }
+
+    /**
+     * Checks console log.
+     *
+     * @param checksName
+     *         check name to use for publishing to SCM
+     */
+    private void checkPublisherDetails(final String checksName) {
+        ChecksDetails checksDetails = ExtensionList.lookupSingleton(InterceptingChecksPublisherFactory.class)
+                .getPublisher().getChecksDetail();
+        if (checksName != null) {
+            assertThat(checksDetails.getName())
+                    .isPresent()
+                    .get()
+                    .isEqualTo(checksName);
+        }
+        else {
+            assertThat(checksDetails.getName())
+                    .isPresent()
+                    .get()
+                    .isEqualTo(DEFAULT_CHECKS_NAME);
+        }
+    }
+
+    /**
+     * Creates freestyle project with jacoco file and adapter.
+     *
+     * @param checksName
+     *         check name to use for publishing to SCM
+     *         if null, uses default checks name
+     *
+     * @return {@link FreeStyleProject} with specified check name.
+     */
+    private FreeStyleProject getFreeStyleProject(final String checksName) {
+        FreeStyleProject job = createFreeStyleProjectWithWorkspaceFiles(JACOCO_FILENAME);
+
+        CoveragePublisher coveragePublisher = new CoveragePublisher();
+        JacocoReportAdapter jacocoReportAdapter = new JacocoReportAdapter(JACOCO_FILENAME);
+        if (checksName != null) {
+            coveragePublisher.setChecksName(checksName);
+            assertThat(coveragePublisher.getChecksName()).isEqualTo(checksName);
+        }
+        else {
+            assertThat(coveragePublisher.getChecksName()).isEqualTo(DEFAULT_CHECKS_NAME);
+        }
+        coveragePublisher.setAdapters(Collections.singletonList(jacocoReportAdapter));
+        job.getPublishersList().add(coveragePublisher);
+        return job;
+    }
+
+    /**
+     * Creates a build of a pipeline project with jacoco file and adapter.
+     *
+     * @param checksName
+     *         check name to use for publishing to SCM
+     *         if null, uses default checks name
+     *
+     * @return {@link WorkflowJob} with specified check name.
+     */
+    private WorkflowJob getPipelineProject(final String checksName) {
+        WorkflowJob job = createPipelineWithWorkspaceFiles(JACOCO_FILENAME);
+        String checksNameArg = "";
+
+        if (checksName != null) {
+            checksNameArg = ",\n    checksName: '" + checksName + "'";
+        }
+        job.setDefinition(new CpsFlowDefinition("node {"
+                + "    publishCoverage adapters: [jacocoAdapter('" + JACOCO_FILENAME + "')]" + checksNameArg
+                + "}", true));
+        return job;
+    }
+
+    static class InterceptingChecksPublisher extends ChecksPublisher {
+
+        private ChecksDetails checksDetail = null;
+
+        @Override
+        public void publish(final ChecksDetails checksDetails) {
+            this.checksDetail = checksDetails;
+        }
+
+        public ChecksDetails getChecksDetail() {
+            return this.checksDetail;
+        }
+    }
+
+    @TestExtension
+    public static class InterceptingChecksPublisherFactory extends ChecksPublisherFactory {
+
+        private final InterceptingChecksPublisher publisher = new InterceptingChecksPublisher();
+
+        @Override
+        protected Optional<ChecksPublisher> createPublisher(final Run<?, ?> run, final TaskListener listener) {
+            return Optional.of(publisher);
+        }
+
+        @Override
+        protected Optional<ChecksPublisher> createPublisher(final Job<?, ?> job, final TaskListener listener) {
+            return Optional.of(publisher);
+        }
+
+        public InterceptingChecksPublisher getPublisher() {
+            return this.publisher;
+        }
+    }
+}

--- a/ui-tests/src/main/java/io/jenkins/plugins/coverage/CoveragePublisher/CoveragePublisher.java
+++ b/ui-tests/src/main/java/io/jenkins/plugins/coverage/CoveragePublisher/CoveragePublisher.java
@@ -30,6 +30,7 @@ public class CoveragePublisher extends AbstractStep implements PostBuildStep {
     private final Control globalThreshold = control("repeatable-add");
     private final Control sourceCodeEncoding = control("sourceCodeEncoding");
     private final Control sourceDirectories = findRepeatableAddButtonFor("sourceDirectories");
+    private final Control checksName = control("checksName");
 
     /**
      * Constructor for CoveragePublisher.
@@ -146,6 +147,17 @@ public class CoveragePublisher extends AbstractStep implements PostBuildStep {
     public void setSkipPublishingChecks(final boolean skipPublishing) {
         ensureAdvancedOptionsIsActivated();
         skipPublishingChecks.check(skipPublishing);
+    }
+
+    /**
+     * Setter for setting the SCM checks name.
+     *
+     * @param checksName
+     *         the SCM check name
+     */
+    public void setChecksName(final String checksName) {
+        ensureAdvancedOptionsIsActivated();
+        this.checksName.set(checksName);
     }
 
     /**


### PR DESCRIPTION
### Description
This fulfills issue https://github.com/jenkinsci/code-coverage-api-plugin/issues/204

Adds a new parameter to the plugin called `checksName` in order to provide a custom checks name to the SCM provider. Will default back to `Code Coverage` if no `checksName` is provided to ensure compatibility isn't broken.

This feature is similar to the one merged into `junit-plugin` https://github.com/jenkinsci/junit-plugin/pull/211.
