### PR TITLE
Fix float precision issue in coverage diff 

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.PrintStream;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -252,7 +254,8 @@ public class CoverageProcessor {
     private void failBuildIfChangeRequestDecreasedCoverage(final CoverageResult coverageResult, final CoverageAction action)
             throws CoverageException {
         float coverageDiff = coverageResult.getCoverageDelta(CoverageElement.LINE);
-        if (coverageDiff < 0) {
+
+        if (roundFloat(coverageDiff,2) < 0) {
             String message = "Fail build because this change request decreases line coverage by " + coverageDiff;
             action.setFailMessage(message);
 
@@ -731,4 +734,15 @@ public class CoverageProcessor {
             return (CoverageResult) ois.readObject();
         }
     }
+
+    /**
+     * Round up float value to specified scaling factor using Round down strategy
+     * @param number
+     * @param scale
+     * @return float value (scaled)
+     */
+    public static float roundFloat(final float number, final int scale) {
+       return BigDecimal.valueOf(number).setScale(scale,RoundingMode.DOWN).floatValue();
+    }
+
 }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -254,11 +254,9 @@ public class CoverageProcessor {
     private void failBuildIfChangeRequestDecreasedCoverage(final CoverageResult coverageResult, final CoverageAction action)
             throws CoverageException {
         float coverageDiff = coverageResult.getCoverageDelta(CoverageElement.LINE);
-
         if (roundFloat(coverageDiff,2) < 0) {
             String message = "Fail build because this change request decreases line coverage by " + coverageDiff;
             action.setFailMessage(message);
-
             throw new CoverageException(message);
         }
     }
@@ -734,7 +732,6 @@ public class CoverageProcessor {
             return (CoverageResult) ois.readObject();
         }
     }
-
     /**
      * Round up float value to specified scaling factor using Round down strategy
      * @param number
@@ -744,5 +741,4 @@ public class CoverageProcessor {
     public static float roundFloat(final float number, final int scale) {
        return BigDecimal.valueOf(number).setScale(scale,RoundingMode.DOWN).floatValue();
     }
-
 }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -732,12 +732,6 @@ public class CoverageProcessor {
             return (CoverageResult) ois.readObject();
         }
     }
-    /**
-     * Round up float value to specified scaling factor using Round down strategy
-     * @param number
-     * @param scale
-     * @return float value (scaled)
-     */
     public static float roundFloat(final float number, final int scale) {
        return BigDecimal.valueOf(number).setScale(scale,RoundingMode.DOWN).floatValue();
     }

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -251,7 +251,7 @@ public class CoverageProcessor {
         return Optional.empty();
     }
 
-    private void failBuildIfChangeRequestDecreasedCoverage(final CoverageResult coverageResult, final CoverageAction action)
+    void failBuildIfChangeRequestDecreasedCoverage(final CoverageResult coverageResult, final CoverageAction action)
             throws CoverageException {
         float coverageDiff = coverageResult.getCoverageDelta(CoverageElement.LINE);
         if (roundFloat(coverageDiff,2) < 0) {

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -732,7 +732,7 @@ public class CoverageProcessor {
             return (CoverageResult) ois.readObject();
         }
     }
-    public static float roundFloat(final float number, final int scale) {
+    static float roundFloat(final float number, final int scale) {
        return BigDecimal.valueOf(number).setScale(scale,RoundingMode.DOWN).floatValue();
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageProcessorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageProcessorTest.java
@@ -1,0 +1,30 @@
+package io.jenkins.plugins.coverage;
+
+import io.jenkins.plugins.coverage.CoveragePublisher.CoveragePublisher;
+import io.jenkins.plugins.coverage.CoveragePublisher.CoveragePublisher.SourceFileResolver;
+import org.jenkinsci.test.acceptance.junit.WithPlugins;
+import org.jenkinsci.test.acceptance.po.Build;
+import org.jenkinsci.test.acceptance.po.FreeStyleJob;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * Acceptance tests for CoverageProcessor. Verifies if set options in CoverageProcessor are used and lead to accepted
+ * results.
+ */
+public class CoverageProcessorTest {
+
+    /**
+     * Test roundFloat method in CoverageProcessor
+     */
+    @Test
+    public void testFloatRounding() {
+        float number=-0.001f;
+        float scaledNumber= CoverageProcessor.roundFloat(number,2);
+        Assert.assertEquals(scaledNumber,0.00);
+    }
+
+}

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageProcessorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageProcessorTest.java
@@ -1,22 +1,15 @@
 package io.jenkins.plugins.coverage;
 
-import io.jenkins.plugins.coverage.CoveragePublisher.CoveragePublisher;
-import io.jenkins.plugins.coverage.CoveragePublisher.CoveragePublisher.SourceFileResolver;
-import org.jenkinsci.test.acceptance.junit.WithPlugins;
-import org.jenkinsci.test.acceptance.po.Build;
-import org.jenkinsci.test.acceptance.po.FreeStyleJob;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import org.jvnet.hudson.test.JenkinsRule;
 
 /**
  * Acceptance tests for CoverageProcessor. Verifies if set options in CoverageProcessor are used and lead to accepted
  * results.
  */
 public class CoverageProcessorTest {
-
+    public JenkinsRule j = new JenkinsRule();
     /**
      * Test roundFloat method in CoverageProcessor
      */
@@ -26,5 +19,4 @@ public class CoverageProcessorTest {
         float scaledNumber= CoverageProcessor.roundFloat(number,2);
         Assert.assertEquals(scaledNumber,0.00);
     }
-
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageProcessorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageProcessorTest.java
@@ -2,14 +2,12 @@ package io.jenkins.plugins.coverage;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
 
 /**
  * Acceptance tests for CoverageProcessor. Verifies if set options in CoverageProcessor are used and lead to accepted
  * results.
  */
 public class CoverageProcessorTest {
-    public JenkinsRule j = new JenkinsRule();
     /**
      * Test roundFloat method in CoverageProcessor
      */

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageProcessorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageProcessorTest.java
@@ -15,6 +15,6 @@ public class CoverageProcessorTest {
     public void testFloatRounding() {
         float number=-0.001f;
         float scaledNumber= CoverageProcessor.roundFloat(number,2);
-        Assert.assertEquals(scaledNumber,0.00);
+        Assert.assertEquals(scaledNumber,0.00,0);
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageProcessorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/CoverageProcessorTest.java
@@ -1,13 +1,34 @@
 package io.jenkins.plugins.coverage;
 
+import hudson.FilePath;
+import hudson.model.Run;
+import io.jenkins.plugins.coverage.exception.CoverageException;
+import io.jenkins.plugins.coverage.targets.CoverageResult;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /**
  * Acceptance tests for CoverageProcessor. Verifies if set options in CoverageProcessor are used and lead to accepted
  * results.
  */
 public class CoverageProcessorTest {
+
+    CoverageProcessor coverageProcessor;
+    CoverageResult coverageResult;
+    CoverageAction coverageAction;
+
+    @Before()
+    public void testInit(){
+        coverageProcessor = new CoverageProcessor(mock(Run.class),mock(FilePath.class),null);
+        coverageResult =mock(CoverageResult.class);
+        coverageAction =mock(CoverageAction.class);
+    }
+
     /**
      * Test roundFloat method in CoverageProcessor
      */
@@ -16,5 +37,27 @@ public class CoverageProcessorTest {
         float number=-0.001f;
         float scaledNumber= CoverageProcessor.roundFloat(number,2);
         Assert.assertEquals(scaledNumber,0.00,0);
+    }
+
+    @Test()
+    public void testChangeRequestDecreasedCoverageNotFailed_NoChange() throws CoverageException {
+        Mockito.when(coverageResult.getCoverageDelta(any())).thenReturn(-0.001f);
+        //No Exception should be thrown
+        coverageProcessor.failBuildIfChangeRequestDecreasedCoverage(coverageResult,coverageAction);
+        verify(coverageAction, times(0)).setFailMessage(any());
+    }
+
+    @Test(expected = CoverageException.class)
+    public void testChangeRequestDecreasedCoverageFailed_DecCoverage() throws CoverageException {
+        Mockito.when(coverageResult.getCoverageDelta(any())).thenReturn(-1.11f);
+        coverageProcessor.failBuildIfChangeRequestDecreasedCoverage(coverageResult,coverageAction);
+        verify(coverageAction, times(1)).setFailMessage(any());
+    }
+
+    @Test()
+    public void testChangeRequestDecreasedCoverageNotFailed_IncCoverage() throws CoverageException {
+        Mockito.when(coverageResult.getCoverageDelta(any())).thenReturn(0.1f);
+        coverageProcessor.failBuildIfChangeRequestDecreasedCoverage(coverageResult,coverageAction);
+        verify(coverageAction, times(0)).setFailMessage(any());
     }
 }


### PR DESCRIPTION
While calculating difference in coverage, there might be a difference even without code change, due to floating point rounding errors. Converting the diff float to BigDecimal with appropriate scale and converting back solves this issue.

Fixes: https://github.com/jenkinsci/code-coverage-api-plugin/issues/191

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
