### PR TITLE
CoverageNode: Fix mergePath for node created from cobertura report

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageNode.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/model/CoverageNode.java
@@ -130,14 +130,16 @@ public class CoverageNode implements Serializable {
 
         if (hasParent()) {
             String parentPath = getParent().getPath();
-
-            if (StringUtils.isBlank(parentPath)) {
+            String slash = "/";
+            if (StringUtils.isBlank(parentPath) || parentPath.equals(slash) || localPath.startsWith(parentPath + slash)) {
+                // do not prepend parent path if empty or if root or if local path starts with it
+                // as it is the case for coverage node created from cobertura report
                 return localPath;
             }
             if (StringUtils.isBlank(localPath)) {
                 return parentPath;
             }
-            return parentPath + "/" + localPath;
+            return parentPath + slash + localPath;
         }
 
         return localPath;

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoverageNodeTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/model/CoverageNodeTest.java
@@ -453,6 +453,43 @@ class CoverageNodeTest extends AbstractCoverageTest {
     }
 
     @Test
+    void shouldReturnCorrectPatshInFileCoverageNodesFromCoberturaReport() {
+        CoverageResult result = readCoberturaResult("cobertura-lots-of-data.xml");
+        CoverageNode tree = new CoverageNodeConverter().convert(result);
+        tree.splitPackages();
+        assertThat(tree.getAllFileCoverageNodes())
+                .hasSize(19)
+                .extracting(FileCoverageNode::getPath)
+                .containsOnly("org/apache/commons/cli/AlreadySelectedException.java",
+                              "org/apache/commons/cli/BasicParser.java",
+                              "org/apache/commons/cli/CommandLine.java",
+                              "org/apache/commons/cli/CommandLineParser.java",
+                              "org/apache/commons/cli/GnuParser.java",
+                              "org/apache/commons/cli/HelpFormatter.java",
+                              "org/apache/commons/cli/MissingArgumentException.java",
+                              "org/apache/commons/cli/MissingOptionException.java",
+                              "org/apache/commons/cli/NumberUtils.java",
+                              "org/apache/commons/cli/Option.java",
+                              "org/apache/commons/cli/OptionBuilder.java",
+                              "org/apache/commons/cli/OptionGroup.java",
+                              "org/apache/commons/cli/Options.java",
+                              "org/apache/commons/cli/ParseException.java",
+                              "org/apache/commons/cli/Parser.java",
+                              "org/apache/commons/cli/PatternOptionBuilder.java",
+                              "org/apache/commons/cli/PosixParser.java",
+                              "org/apache/commons/cli/TypeHandler.java",
+                              "org/apache/commons/cli/UnrecognizedOptionException.java");
+
+        result = readCoberturaResult("cobertura-package-root.xml");
+        tree = new CoverageNodeConverter().convert(result);
+        tree.splitPackages();
+        assertThat(tree.getAllFileCoverageNodes())
+                .hasSize(1)
+                .extracting(FileCoverageNode::getPath)
+                .containsOnly("__init__.py");
+    }
+
+    @Test
     void shouldProvideExistentChangeCoverage() {
         CoverageNode tree = createTreeWithMockedTreeCreator();
         assertThat(tree.hasCodeChanges()).isTrue();

--- a/plugin/src/test/resources/io/jenkins/plugins/coverage/model/cobertura-package-root.xml
+++ b/plugin/src/test/resources/io/jenkins/plugins/coverage/model/cobertura-package-root.xml
@@ -1,0 +1,40 @@
+<coverage branch-rate="0.8337" branches-covered="396" branches-valid="475" complexity="0"
+  line-rate="0.9448" lines-covered="2514" lines-valid="2661" timestamp="1674553788337"
+  version="7.0.5">
+  <sources>
+    <source>
+      /home/user/dev/python/package
+    </source>
+  </sources>
+  <packages>
+    <package branch-rate="0.6759" complexity="0" line-rate="0.8305" name=".">
+      <classes>
+        <class branch-rate="1" complexity="0" filename="__init__.py" line-rate="1"
+          name="__init__.py">
+          <methods />
+          <lines>
+            <line hits="1" number="6" />
+            <line hits="1" number="8" />
+            <line hits="1" number="9" />
+            <line hits="1" number="10" />
+            <line hits="1" number="11" />
+            <line hits="1" number="13" />
+            <line hits="1" number="16" />
+            <line hits="1" number="25" />
+            <line branch="true" condition-coverage="100% (2/2)" hits="1" number="41" />
+            <line hits="1" number="42" />
+            <line hits="1" number="46" />
+            <line hits="1" number="48" />
+            <line branch="true" condition-coverage="100% (2/2)" hits="1" number="49" />
+            <line hits="1" number="50" />
+            <line hits="1" number="54" />
+            <line hits="1" number="55" />
+            <line hits="1" number="56" />
+            <line hits="1" number="57" />
+            <line hits="1" number="60" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>


### PR DESCRIPTION
When a coverage node has been created from a cobertura report, the `mergePath` method was returning a wrong path if the provided local path contains any subpaths in it. Those subpaths were prepended to the local path thus doubling them in the merged path (for instance `"a/b/c"` was transformed to `"a/b/a/b/c"`).

As a consequence, `FileCoverageNode.getPath` was returning a wrong file path which prevented any source file painting and display in the Jenkins UI.

Fixes #456.

For the record, I deployed that fix to the Jenkins instance we are using in our development team and [source file coverage display](https://jenkins.softwareheritage.org/job/DVAU/job/gitlab-builds/6/coverage/) is now working when using cobertura reports. 

The fix seems pretty harmless to me, surely not the best one but I guess other users of the plugin encountering the same bug will be happy to have the display of coverage painting on source files back as it is quite frustrating to not have it.
