### PR TITLE
Ignore quality gates if the actual value does not exist

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageQualityGateEvaluator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageQualityGateEvaluator.java
@@ -36,7 +36,7 @@ class CoverageQualityGateEvaluator extends QualityGateEvaluator<CoverageQualityG
             result.add(qualityGate, status, FORMATTER.format(actualValue, Locale.ENGLISH));
         }
         else {
-            result.add(qualityGate, qualityGate.getStatus(), "n/a");
+            result.add(qualityGate, QualityGateStatus.INACTIVE, "n/a");
         }
     }
 }

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/AbstractCoverageTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/AbstractCoverageTest.java
@@ -75,6 +75,16 @@ public abstract class AbstractCoverageTest extends ResourceTest {
                 fillValues(), fillDeltas());
     }
 
+    /**
+     * Creates coverage statistics that can be used in test cases.
+     *
+     * @return the coverage statistics
+     */
+    public static CoverageStatistics createOnlyProjectStatistics() {
+        return new CoverageStatistics(fillValues(),
+                new TreeMap<>(), List.of(), new TreeMap<>(), List.of(), new TreeMap<>());
+    }
+
     private static List<Value> fillValues() {
         var builder = new CoverageBuilder();
         return List.of(builder.setMetric(Metric.FILE).setCovered(3).setMissed(1).build(),

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageQualityGateEvaluatorTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageQualityGateEvaluatorTest.java
@@ -67,6 +67,30 @@ class CoverageQualityGateEvaluatorTest extends AbstractCoverageTest {
     }
 
     @Test
+    void shouldSkipIfValueNotDefined() {
+        Collection<CoverageQualityGate> qualityGates = new ArrayList<>();
+
+        qualityGates.add(new CoverageQualityGate(0, Metric.FILE, Baseline.MODIFIED_LINES, QualityGateCriticality.UNSTABLE));
+        qualityGates.add(new CoverageQualityGate(0, Metric.FILE, Baseline.MODIFIED_FILES, QualityGateCriticality.UNSTABLE));
+        qualityGates.add(new CoverageQualityGate(0, Metric.LINE, Baseline.PROJECT_DELTA, QualityGateCriticality.UNSTABLE));
+        qualityGates.add(new CoverageQualityGate(0, Metric.FILE, Baseline.MODIFIED_LINES_DELTA, QualityGateCriticality.UNSTABLE));
+        qualityGates.add(new CoverageQualityGate(0, Metric.LINE, Baseline.MODIFIED_FILES_DELTA, QualityGateCriticality.UNSTABLE));
+
+        CoverageQualityGateEvaluator evaluator = new CoverageQualityGateEvaluator(qualityGates, createOnlyProjectStatistics());
+
+        assertThat(evaluator).isEnabled();
+
+        QualityGateResult result = evaluator.evaluate();
+
+        assertThat(result).hasOverallStatus(QualityGateStatus.INACTIVE).isInactive().hasMessages(
+                "-> [Modified code lines - File Coverage]: ≪Not built≫ - (Actual value: n/a, Quality gate: 0.00)",
+                "-> [Modified files - File Coverage]: ≪Not built≫ - (Actual value: n/a, Quality gate: 0.00)",
+                "-> [Overall project (difference to reference job) - Line Coverage]: ≪Not built≫ - (Actual value: n/a, Quality gate: 0.00)",
+                "-> [Modified code lines (difference to modified files) - File Coverage]: ≪Not built≫ - (Actual value: n/a, Quality gate: 0.00)",
+                "-> [Modified files (difference to overall project) - Line Coverage]: ≪Not built≫ - (Actual value: n/a, Quality gate: 0.00)");
+    }
+
+    @Test
     void shouldReportUnstableIfBelowThreshold() {
         Collection<CoverageQualityGate> qualityGates = new ArrayList<>();
 
@@ -150,18 +174,6 @@ class CoverageQualityGateEvaluatorTest extends AbstractCoverageTest {
 
         CoverageQualityGateEvaluator evaluator = new CoverageQualityGateEvaluator(qualityGates, createStatistics());
         assertThatStatusWillBeOverwritten(evaluator);
-    }
-
-    @Test
-    void shouldFailIfValueIsNotFound() {
-        Collection<CoverageQualityGate> qualityGates = new ArrayList<>();
-
-        qualityGates.add(new CoverageQualityGate(50.0, Metric.PACKAGE, Baseline.PROJECT, QualityGateCriticality.FAILURE));
-
-        CoverageQualityGateEvaluator evaluator = new CoverageQualityGateEvaluator(qualityGates, createStatistics());
-        QualityGateResult result = evaluator.evaluate();
-        assertThat(result).hasOverallStatus(QualityGateStatus.FAILED).isNotSuccessful().hasMessages(
-                "-> [Overall project - Package Coverage]: ≪Failed≫ - (Actual value: n/a, Quality gate: 50.00)");
     }
 
     @Test


### PR DESCRIPTION
When a value does not exist (because the reference build is not available, or there are no code changes), then the quality gate evaluation should be skipped.

Fixes https://github.com/jenkinsci/code-coverage-api-plugin/issues/579.

