### PR TITLE
Use predefined sources of modules to search for source code

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -32,7 +32,7 @@
     <testcontainers.version>1.17.6</testcontainers.version>
     <job-dsl.version>1.83</job-dsl.version>
 
-    <coverage-model.version>0.19.0</coverage-model.version>
+    <coverage-model.version>0.19.1</coverage-model.version>
     <git-forensics.version>2.0.0</git-forensics.version>
     <prism-api.version>1.29.0-3</prism-api.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>


### PR DESCRIPTION
Uses the predefined `sources` value of the Cobertura XML file, so that the source code files will be found by Jenkins.

Additionally, upgrades the coverage-model to [0.19.1](https://github.com/jenkinsci/coverage-model/releases) that contains the fix for #599.