### PR TITLE
Use buffered reads when recovering coverage result.

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/CoverageProcessor.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.coverage;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -728,7 +729,7 @@ public class CoverageProcessor {
     public static CoverageResult recoverCoverageResult(final Run<?, ?> run) throws IOException, ClassNotFoundException {
         File reportFile = new File(run.getRootDir(), DEFAULT_REPORT_SAVE_NAME);
 
-        try (ObjectInputStream ois = new CompatibleObjectInputStream(new FileInputStream(reportFile))) {
+        try (ObjectInputStream ois = new CompatibleObjectInputStream(new BufferedInputStream(new FileInputStream(reportFile)))) {
             return (CoverageResult) ois.readObject();
         }
     }


### PR DESCRIPTION
Use buffered reads when recovering coverage result.

After we started using this plugin, 
we noticed fairly large number of 1 byte reads hitting NFS  server hurting performance.

1 byte reads seems to be coming from [PeekInputStream calls used inside ObjectInputStream](https://github.com/AdoptOpenJDK/openjdk-jdk8u/blob/master/jdk/src/share/classes/java/io/ObjectInputStream.java#L2755) 
directly hitting FileInputStream.

This PR attempts to mitigate the issue by inserting BufferedInputStream to reduce number of small size reads
directly hitting the file system.
 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
