### PR TITLE
Bump version of coverage-model to 0.22.1

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -19,7 +19,7 @@
   <url>https://github.com/jenkinsci/code-coverage-api-plugin</url>
 
   <properties>
-    <revision>4.3.0</revision>
+    <revision>4.2.1</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/code-coverage-api-plugin</gitHubRepo>
 

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -32,7 +32,7 @@
     <testcontainers.version>1.18.0</testcontainers.version>
     <job-dsl.version>1.83</job-dsl.version>
 
-    <coverage-model.version>0.22.0</coverage-model.version>
+    <coverage-model.version>0.22.1</coverage-model.version>
     <git-forensics.version>2.0.0</git-forensics.version>
     <prism-api.version>1.29.0-4</prism-api.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/code-coverage-api-plugin/issues/630.

Release notes:
https://github.com/jenkinsci/coverage-model/releases/tag/v0.22.1
