### PR TITLE
Use the correct ID of the action when comparing with reference build

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
@@ -520,6 +520,7 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
      *
      * @return {@code true} if the trend is positive, {@code false} otherwise
      */
+    @SuppressWarnings("unused") // Called by jelly view
     public boolean isPositiveTrend(final Baseline baseline, final Metric metric) {
         var delta = getDelta(baseline, metric);
         if (delta.isPresent()) {
@@ -555,7 +556,7 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
     }
 
     /**
-     * Renders the reference build as HTML link.
+     * Renders the reference build as HTML-link.
      *
      * @return the reference build
      * @see #getReferenceBuild()


### PR DESCRIPTION
A reference build might contain different coverage actions with different IDs. When computing the delta, we need to select the action with the same ID to make the results comparable.

Example from PR #670 that did not change any code. The mutation coverage is compared with the code coverage 🐛 

![Bildschirmfoto 2023-05-10 um 20 34 20](https://github.com/jenkinsci/code-coverage-api-plugin/assets/503338/dfd0fa6b-a63a-4419-ac81-b101b584fc76)

