### PR TITLE
A branch coverage of 0/n should be named "No branches covered"

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinter.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinter.java
@@ -84,6 +84,9 @@ class CoverageSourcePrinter implements Serializable {
             if (missed == 0) {
                 return "All branches covered";
             }
+            if (covered == 0) {
+                return "No branches covered";
+            }
             return String.format("Partially covered, branch coverage: %d/%d", covered, covered + missed);
         }
         else if (covered == 1) {

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinterTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/source/CoverageSourcePrinterTest.java
@@ -45,6 +45,17 @@ class CoverageSourcePrinterTest extends AbstractCoverageTest {
     }
 
     @Test
+    void shouldRenderNoBrnachCoverage() {
+        var tree = readResult("../steps/jacoco-analysis-model.xml", new JacocoParser());
+
+        var file = new CoverageSourcePrinter(tree.findFile("LineRangeList.java").get());
+
+        assertThat(file.getSummaryColumn(265)).isEqualTo("0/2");
+        assertThat(file.getTooltip(265)).isEqualTo("No branches covered");
+        assertThat(file.getColorClass(265)).isEqualTo(CoverageSourcePrinter.NO_COVERAGE);
+    }
+
+    @Test
     void shouldRenderWholeLine() {
         var tree = readResult("../steps/jacoco-codingstyle.xml", new JacocoParser());
 


### PR DESCRIPTION
Before that change, it was called "partially covered".
