### PR TITLE
Use BOM version for ECharts

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -34,7 +34,7 @@
 
     <coverage-model.version>0.24.0</coverage-model.version>
     <git-forensics.version>2.0.0</git-forensics.version>
-    <prism-api.version>1.29.0-6</prism-api.version>
+    <prism-api.version>1.29.0-7</prism-api.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>
 
   </properties>
@@ -154,7 +154,6 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>echarts-api</artifactId>
-      <version>5.4.0-4</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>


### PR DESCRIPTION
The correct version of ECharts is now part of the BOM.