### PR TITLE
Convert delta fractions to percentages when used in quality gates

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageQualityGateEvaluator.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageQualityGateEvaluator.java
@@ -3,6 +3,13 @@ package io.jenkins.plugins.coverage.metrics.steps;
 import java.util.Collection;
 import java.util.Locale;
 
+import org.apache.commons.lang3.math.Fraction;
+
+import edu.hm.hafner.coverage.FractionValue;
+import edu.hm.hafner.coverage.Metric;
+import edu.hm.hafner.coverage.SafeFraction;
+import edu.hm.hafner.coverage.Value;
+
 import io.jenkins.plugins.coverage.metrics.model.CoverageStatistics;
 import io.jenkins.plugins.coverage.metrics.model.ElementFormatter;
 import io.jenkins.plugins.util.QualityGateEvaluator;
@@ -15,10 +22,13 @@ import io.jenkins.plugins.util.QualityGateStatus;
  * @author Johannes Walter
  */
 class CoverageQualityGateEvaluator extends QualityGateEvaluator<CoverageQualityGate> {
+    private static final Fraction HUNDRED = Fraction.getFraction("100.0");
+
     private static final ElementFormatter FORMATTER = new ElementFormatter();
     private final CoverageStatistics statistics;
 
-    CoverageQualityGateEvaluator(final Collection<? extends CoverageQualityGate> qualityGates, final CoverageStatistics statistics) {
+    CoverageQualityGateEvaluator(final Collection<? extends CoverageQualityGate> qualityGates,
+            final CoverageStatistics statistics) {
         super(qualityGates);
 
         this.statistics = statistics;
@@ -29,14 +39,41 @@ class CoverageQualityGateEvaluator extends QualityGateEvaluator<CoverageQualityG
         var baseline = qualityGate.getBaseline();
         var possibleValue = statistics.getValue(baseline, qualityGate.getMetric());
         if (possibleValue.isPresent()) {
-            var actualValue = possibleValue.get();
+            var actualValue = convertActualValue(possibleValue.get());
 
             var status = actualValue.isOutOfValidRange(
                     qualityGate.getThreshold()) ? qualityGate.getStatus() : QualityGateStatus.PASSED;
-            result.add(qualityGate, status, FORMATTER.format(actualValue, Locale.ENGLISH));
+            result.add(qualityGate, status, FORMATTER.format(possibleValue.get(), Locale.ENGLISH));
         }
         else {
             result.add(qualityGate, QualityGateStatus.INACTIVE, "n/a");
         }
+    }
+
+    /**
+     * Converts the actual value to a percentage if necessary. Delta values are internally stored as fractions, but
+     * users expect percentages when they are displayed or used in thresholds.
+     *
+     * @param value
+     *         the actual stored value
+     *
+     * @return the converted value
+     */
+    private Value convertActualValue(final Value value) {
+        var metric = value.getMetric();
+        if (metric.equals(Metric.COMPLEXITY)
+                || metric.equals(Metric.COMPLEXITY_MAXIMUM)
+                || metric.equals(Metric.LOC)) {
+            return value; // ignore integer based metrics
+        }
+        if (value instanceof FractionValue) { // delta percentage
+            return new FractionValue(metric, covertToPercentage((FractionValue) value));
+        }
+
+        return value;
+    }
+
+    private Fraction covertToPercentage(final FractionValue value) {
+        return new SafeFraction(value.getFraction()).multiplyBy(HUNDRED);
     }
 }


### PR DESCRIPTION
Delta values are internally stored as fractions, but a user expects them as percentages when they are displayed or used in thresholds. So values in the range [-1, 1] should be converted to percentages in the range [-100%, 100%] before passed to the quality gate evaluation.

Fixes https://github.com/jenkinsci/code-coverage-api-plugin/issues/689


