### PR TITLE
Redraw the trend charts when user changes color theme (dark/light mode)

### DIFF
--- a/plugin/src/main/webapp/js/view-model.js
+++ b/plugin/src/main/webapp/js/view-model.js
@@ -457,6 +457,16 @@ const CoverageChartGenerator = function ($) {
             redrawCharts();
         });
 
+        if (window.getThemeManagerProperty && window.isSystemRespectingTheme) {
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => {
+                redrawCharts();
+
+                viewProxy.getOverview(function (t) {
+                    createOverview(t.responseObject(), 'coverage-overview');
+                });
+            });
+        }
+
         $(document).ready(function () {
             initializeSourceCodeSelection('absolute-coverage');
             initializeSourceCodeSelection('change-coverage');


### PR DESCRIPTION
When the users (or the system) changes from dark to light mode (or the other way round), then the charts need to be re-rendered to use the correct background and foreground colors.  