### PR TITLE
Add a new option to ignore parser errors

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -33,7 +33,7 @@
     <testcontainers.version>1.19.1</testcontainers.version>
     <job-dsl.version>1.84</job-dsl.version>
 
-    <coverage-model.version>0.25.0</coverage-model.version>
+    <coverage-model.version>0.27.0</coverage-model.version>
     <git-forensics.version>2.0.0</git-forensics.version>
     <prism-api.version>1.29.0-8</prism-api.version>
     <pull-request-monitoring.version>1.7.8</pull-request-monitoring.version>

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageReportScanner.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageReportScanner.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.ModuleNode;
 import edu.hm.hafner.util.FilteredLog;
 import edu.hm.hafner.util.PathUtil;
@@ -26,31 +27,36 @@ public class CoverageReportScanner extends AgentFileVisitor<ModuleNode> {
     private static final long serialVersionUID = 6940864958150044554L;
 
     private static final PathUtil PATH_UTIL = new PathUtil();
+
     private final Parser parser;
+    private final ProcessingMode processingMode;
 
     /**
      * Creates a new instance of {@link CoverageReportScanner}.
      *
+     * @param parser
+     *         the parser to use
      * @param filePattern
      *         ant file-set pattern to scan for files to parse
      * @param encoding
      *         encoding of the files to parse
      * @param followSymbolicLinks
      *         if the scanner should traverse symbolic links
-     * @param parser
-     *         the parser to use
+     * @param processingMode
+     *         determines whether to ignore errors
      */
-    public CoverageReportScanner(final String filePattern, final String encoding,
-            final boolean followSymbolicLinks, final Parser parser) {
+    public CoverageReportScanner(final Parser parser, final String filePattern, final String encoding,
+            final boolean followSymbolicLinks, final ProcessingMode processingMode) {
         super(filePattern, encoding, followSymbolicLinks, true);
 
         this.parser = parser;
+        this.processingMode = processingMode;
     }
 
     @Override
     protected Optional<ModuleNode> processFile(final Path file, final Charset charset, final FilteredLog log) {
         try {
-            CoverageParser xmlParser = parser.createParser();
+            CoverageParser xmlParser = parser.createParser(processingMode);
             ModuleNode node = xmlParser.parse(Files.newBufferedReader(file, charset), log);
             log.logInfo("Successfully parsed file '%s'", PATH_UTIL.getAbsolutePath(file));
             node.aggregateValues().forEach(v -> log.logInfo("%s", v));

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageStep.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageStep.java
@@ -62,6 +62,7 @@ public class CoverageStep extends Step implements Serializable {
     private boolean skipPublishingChecks = false;
     private String checksName =  StringUtils.EMPTY;
     private ChecksAnnotationScope checksAnnotationScope = ChecksAnnotationScope.MODIFIED_LINES;
+    private boolean ignoreParsingErrors = false;
     private boolean failOnError = false;
     private boolean enabledForFailure = false;
     private boolean skipSymbolicLinks = false;
@@ -215,6 +216,21 @@ public class CoverageStep extends Step implements Serializable {
     }
 
     /**
+     * Specify if parsing errors should be ignored and logged instead of throwing an exception.
+     *
+     * @param ignoreParsingErrors
+     *         if parsing errors should be ignored and logged instead of throwing an exception
+     */
+    @DataBoundSetter
+    public void setIgnoreParsingErrors(final boolean ignoreParsingErrors) {
+        this.ignoreParsingErrors = ignoreParsingErrors;
+    }
+
+    public boolean isIgnoreParsingErrors() {
+        return ignoreParsingErrors;
+    }
+
+    /**
      * Determines whether to fail the step on errors during the step of recording coverage reports.
      *
      * @param failOnError
@@ -337,6 +353,7 @@ public class CoverageStep extends Step implements Serializable {
             recorder.setSkipPublishingChecks(step.isSkipPublishingChecks());
             recorder.setChecksName(step.getChecksName());
             recorder.setChecksAnnotationScope(step.getChecksAnnotationScope());
+            recorder.setIgnoreParsingErrors(step.isIgnoreParsingErrors());
             recorder.setFailOnError(step.isFailOnError());
             recorder.setEnabledForFailure(step.isEnabledForFailure());
             recorder.setScm(step.getScm());

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTool.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageTool.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import org.apache.commons.lang3.StringUtils;
 
 import edu.hm.hafner.coverage.CoverageParser;
+import edu.hm.hafner.coverage.CoverageParser.ProcessingMode;
 import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.registry.ParserRegistry;
 import edu.hm.hafner.util.VisibleForTesting;
@@ -235,10 +236,13 @@ public class CoverageTool extends AbstractDescribableImpl<CoverageTool> implemen
         /**
          * Creates a new parser to read the report XML files into a Java object model of {@link Node} instances.
          *
+         * @param processingMode
+         *         determines whether to ignore errors
+         *
          * @return the parser
          */
-        public CoverageParser createParser() {
-            return new ParserRegistry().getParser(name());
+        public CoverageParser createParser(final ProcessingMode processingMode) {
+            return new ParserRegistry().getParser(name(), processingMode);
         }
     }
 }

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder/help-ignoreParsingErrors.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageRecorder/help-ignoreParsingErrors.html
@@ -1,0 +1,7 @@
+<div>
+    This toggle determines if the coverage plugin should ignore parsing errors during processing of the coverage
+    reports or if it should fail fast with an exception. By default this toggle is disabled and the
+    parsers will fail fast. This helps to identify bugs in the parser or in the coverage tool execution.
+    If you would rather like to ignore parsing errors, please tick this checkbox. Please note, that in this
+    case the parser results might be incomplete or even wrong.
+</div>

--- a/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageStep/help-ignoreParsingErrors.html
+++ b/plugin/src/main/resources/io/jenkins/plugins/coverage/metrics/steps/CoverageStep/help-ignoreParsingErrors.html
@@ -1,0 +1,7 @@
+<div>
+    This toggle determines if the coverage plugin should ignore parsing errors during processing of the coverage
+    reports or if it should fail fast with an exception. By default this toggle is disabled and the
+    parsers will fail fast. This helps to identify bugs in the parser or in the coverage tool execution.
+    If you would rather like to ignore parsing errors, please tick this checkbox. Please note, that in this
+    case the parser results might be incomplete or even wrong.
+</div>

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoveragePluginITest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoveragePluginITest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.*;
  */
 class CoveragePluginITest extends AbstractCoverageITest {
     private static final String COBERTURA_HIGHER_COVERAGE_FILE = "cobertura-higher-coverage.xml";
-    private static final int COBERTURA_COVERED_LINES = 7;
+    private static final int COBERTURA_COVERED_LINES = 8;
     private static final int COBERTURA_MISSED_LINES = 0;
     private static final String NO_FILES_FOUND_ERROR_MESSAGE = "[-ERROR-] No files found for pattern '**/*xml'. Configuration error?";
 

--- a/plugin/src/test/resources/io/jenkins/plugins/coverage/metrics/steps/cobertura-duplicate-methods.xml
+++ b/plugin/src/test/resources/io/jenkins/plugins/coverage/metrics/steps/cobertura-duplicate-methods.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<coverage line-rate="0.8301000000000001" branch-rate="0.75" version="1.9" timestamp="1663310122" lines-covered="44"
+          lines-valid="53" branches-covered="3" branches-valid="4">
+  <sources>
+    <source>/CoverageTest.Service/</source>
+  </sources>
+  <packages>
+    <package name="CoverageTest.Service" line-rate="0.8301000000000001" branch-rate="0.75" complexity="8">
+      <classes>
+        <class name="VisualOn.Data.DataSourceProvider" filename="src/VisualOn.Core/Data/DataSourceProvider.cs"
+               line-rate="0.925" branch-rate="0.7692307692307693" complexity="18">
+          <methods>
+            <method name="Enumerate" signature="()" line-rate="1" branch-rate="1" complexity="2">
+              <lines>
+                <line number="61" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+                <line number="63" hits="2" branch="false"/>
+                <line number="65" hits="1" branch="false"/>
+              </lines>
+            </method>
+            <method name="Enumerate" signature="()" line-rate="1" branch-rate="1" complexity="2">
+              <lines>
+                <line number="69" hits="1" branch="false"/>
+                <line number="71" hits="1" branch="true" condition-coverage="100% (2/2)"/>
+                <line number="73" hits="1" branch="false"/>
+                <line number="75" hits="1" branch="false"/>
+              </lines>
+            </method>
+          </methods>
+          <lines>
+            <line number="13" hits="2" branch="false"/>
+            <line number="15" hits="2" branch="false"/>
+            <line number="16" hits="2" branch="false"/>
+            <line number="17" hits="2" branch="false"/>
+            <line number="20" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="24" hits="2" branch="false"/>
+            <line number="25" hits="2" branch="true" condition-coverage="100% (4/4)"/>
+            <line number="26" hits="2" branch="false"/>
+            <line number="28" hits="2" branch="false"/>
+            <line number="30" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="33" hits="2" branch="false"/>
+            <line number="37" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="38" hits="1" branch="false"/>
+            <line number="40" hits="2" branch="false"/>
+            <line number="41" hits="2" branch="false"/>
+            <line number="46" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="47" hits="0" branch="false"/>
+            <line number="48" hits="2" branch="false"/>
+            <line number="53" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="54" hits="0" branch="false"/>
+            <line number="56" hits="2" branch="false"/>
+            <line number="61" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="63" hits="2" branch="false"/>
+            <line number="65" hits="1" branch="false"/>
+            <line number="69" hits="1" branch="false"/>
+            <line number="71" hits="1" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="73" hits="1" branch="false"/>
+            <line number="75" hits="1" branch="false"/>
+            <line number="77" hits="1" branch="false"/>
+            <line number="81" hits="2" branch="true" condition-coverage="50% (1/2)"/>
+            <line number="82" hits="0" branch="false"/>
+            <line number="84" hits="2" branch="false"/>
+            <line number="85" hits="2" branch="false"/>
+            <line number="87" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="88" hits="2" branch="false"/>
+            <line number="90" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="91" hits="2" branch="false"/>
+            <line number="93" hits="2" branch="true" condition-coverage="100% (2/2)"/>
+            <line number="94" hits="2" branch="false"/>
+            <line number="96" hits="2" branch="false"/>
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>


### PR DESCRIPTION
For more details, please see https://github.com/jenkinsci/coverage-model/pull/39.

Fixes https://github.com/jenkinsci/code-coverage-api-plugin/issues/785