### PR TITLE
Do not use color for unchanged coverage #777

### DIFF
--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
@@ -544,22 +544,20 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
      * @param metric
      *         the metric to check
      *
-     * @return {@code roundedDeltaValue} if the trend is positive or negative, {@code 0} otherwise
+     * @return a positive value if the trend is positive, a negative value if the trend is negative, or {@code 0} if there is no significant change in the trend
      */
     @SuppressWarnings("unused") // Called by jelly view
     public double getTrend(final Baseline baseline, final Metric metric) {
         var delta = getDelta(baseline, metric);
         if (delta.isPresent()) {
             double deltaValue = delta.get().doubleValue();
-            // to apply rounding off for boundary delta values
-            double roundedDelta = Math.round(deltaValue * 100.0) / 100.0;
-            if (-0.1 < roundedDelta && roundedDelta < 0.1) {
+            if (-0.001 < deltaValue && deltaValue < 0.001) {
                 // for var(--text-color)
                 return 0;
             }
             else {
                 // for var(--red or --green)
-                return roundedDelta;
+                return deltaValue;
             }
         }
         return 0; // default to zero

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
@@ -18,7 +18,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.Fraction;
 
 import edu.hm.hafner.coverage.Metric;
-import edu.hm.hafner.coverage.Metric.MetricTendency;
 import edu.hm.hafner.coverage.Node;
 import edu.hm.hafner.coverage.Value;
 import edu.hm.hafner.echarts.ChartModelConfiguration;

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
@@ -544,26 +544,22 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
      * @param metric
      *         the metric to check
      *
-     * @return {@code 1} if the trend is positive, {@code -1} if the trend is negative, {@code 0} otherwise
+     * @return {@code roundedDeltaValue} if the trend is positive or negative, {@code 0} otherwise
      */
     @SuppressWarnings("unused") // Called by jelly view
-    public int getTrend(final Baseline baseline, final Metric metric) {
+    public double getTrend(final Baseline baseline, final Metric metric) {
         var delta = getDelta(baseline, metric);
         if (delta.isPresent()) {
             double deltaValue = delta.get().doubleValue();
-            // to apply rounding off
+            // to apply rounding off for boundary delta values
             double roundedDelta = Math.round(deltaValue * 100.0) / 100.0;
-            if (roundedDelta < 0){
-                // for var(-red)
-                return -1;
-            }
-            else if (roundedDelta > 0){
-                // for var(--green)
-                return 1;
-            }
-            else{
+            if (-0.1 < roundedDelta && roundedDelta < 0.1) {
                 // for var(--text-color)
                 return 0;
+            }
+            else {
+                // for var(--red or --green)
+                return roundedDelta;
             }
         }
         return 0; // default to zero

--- a/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
+++ b/plugin/src/main/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildAction.java
@@ -544,18 +544,29 @@ public final class CoverageBuildAction extends BuildAction<Node> implements Stap
      * @param metric
      *         the metric to check
      *
-     * @return {@code true} if the trend is positive, {@code false} otherwise
+     * @return {@code 1} if the trend is positive, {@code -1} if the trend is negative, {@code 0} otherwise
      */
     @SuppressWarnings("unused") // Called by jelly view
-    public boolean isPositiveTrend(final Baseline baseline, final Metric metric) {
+    public int getTrend(final Baseline baseline, final Metric metric) {
         var delta = getDelta(baseline, metric);
         if (delta.isPresent()) {
-            if (delta.get().compareTo(Fraction.ZERO) > 0) {
-                return metric.getTendency() == MetricTendency.LARGER_IS_BETTER;
+            double deltaValue = delta.get().doubleValue();
+            // to apply rounding off
+            double roundedDelta = Math.round(deltaValue * 100.0) / 100.0;
+            if (roundedDelta < 0){
+                // for var(-red)
+                return -1;
             }
-            return metric.getTendency() == MetricTendency.SMALLER_IS_BETTER;
+            else if (roundedDelta > 0){
+                // for var(--green)
+                return 1;
+            }
+            else{
+                // for var(--text-color)
+                return 0;
+            }
         }
-        return true;
+        return 0; // default to zero
     }
 
     /**

--- a/plugin/src/main/resources/coverage/coverage-summary.jelly
+++ b/plugin/src/main/resources/coverage/coverage-summary.jelly
@@ -60,10 +60,10 @@
             <li>${formatter.formatValueWithMetric(value)}
               <j:if test="${it.hasDelta(baseline, value.metric)}">
                 <j:choose>
-                  <j:when test="${it.getTrend(baseline, value.metric) > 0}">
+                  <j:when test="${it.getTrend(baseline, value.metric) gt 0}">
                     <j:set var="color" value="var(--green)"/>
                   </j:when>
-                  <j:when test="${it.getTrend(baseline, value.metric) < 0}">
+                  <j:when test="${it.getTrend(baseline, value.metric) lt 0}">
                     <j:set var="color" value="var(--red)"/>
                   </j:when>
                   <j:otherwise>

--- a/plugin/src/main/resources/coverage/coverage-summary.jelly
+++ b/plugin/src/main/resources/coverage/coverage-summary.jelly
@@ -60,12 +60,12 @@
             <li>${formatter.formatValueWithMetric(value)}
               <j:if test="${it.hasDelta(baseline, value.metric)}">
                 <j:choose>
-                  <j:if test="${it.getTrend(baseline, value.metric) > 0}">
+                  <j:when test="${it.getTrend(baseline, value.metric) > 0}">
                     <j:set var="color" value="var(--green)"/>
-                  </j:if>
-                  <j:if test="${it.getTrend(baseline, value.metric) < 0}">
+                  </j:when>
+                  <j:when test="${it.getTrend(baseline, value.metric) < 0}">
                     <j:set var="color" value="var(--red)"/>
-                  </j:if>
+                  </j:when>
                   <j:otherwise>
                     <j:set var="color" value="var(--text-color)"/>
                   </j:otherwise>

--- a/plugin/src/main/resources/coverage/coverage-summary.jelly
+++ b/plugin/src/main/resources/coverage/coverage-summary.jelly
@@ -60,11 +60,14 @@
             <li>${formatter.formatValueWithMetric(value)}
               <j:if test="${it.hasDelta(baseline, value.metric)}">
                 <j:choose>
-                  <j:when test="${it.isPositiveTrend(baseline, value.metric)}">
+                  <j:when test="${it.getTrend(baseline, value.metric) > 0}">
                     <j:set var="color" value="var(--green)"/>
                   </j:when>
-                  <j:otherwise>
+                  <j:when test="${it.getTrend(baseline, value.metric) < 0}">
                     <j:set var="color" value="var(--red)"/>
+                  </j:when>
+                  <j:otherwise>
+                    <j:set var="color" value="var(--text-color)"/>
                   </j:otherwise>
                 </j:choose>
                 <span style="color: ${color}">(${it.formatDelta(baseline, value.metric)})</span>

--- a/plugin/src/main/resources/coverage/coverage-summary.jelly
+++ b/plugin/src/main/resources/coverage/coverage-summary.jelly
@@ -60,12 +60,12 @@
             <li>${formatter.formatValueWithMetric(value)}
               <j:if test="${it.hasDelta(baseline, value.metric)}">
                 <j:choose>
-                  <j:when test="${it.getTrend(baseline, value.metric) > 0}">
+                  <j:if test="${it.getTrend(baseline, value.metric) > 0}">
                     <j:set var="color" value="var(--green)"/>
-                  </j:when>
-                  <j:when test="${it.getTrend(baseline, value.metric) < 0}">
+                  </j:if>
+                  <j:if test="${it.getTrend(baseline, value.metric) < 0}">
                     <j:set var="color" value="var(--red)"/>
-                  </j:when>
+                  </j:if>
                   <j:otherwise>
                     <j:set var="color" value="var(--text-color)"/>
                   </j:otherwise>

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildActionTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildActionTest.java
@@ -31,7 +31,8 @@ import static org.mockito.Mockito.*;
  */
 @DefaultLocale("en")
 class CoverageBuildActionTest {
-    private CoverageBuildAction createCoverageBuildActionWithDelta(final Baseline Baseline, final Metric metric, Optional<Fraction> delta) {
+    @SuppressWarnings("unused")
+    private CoverageBuildAction createCoverageBuildActionWithDelta(final Baseline baseline, final Metric metric, final Optional<Fraction> delta) {
         Node module = new ModuleNode("module");
 
         var coverageBuilder = new CoverageBuilder();
@@ -110,13 +111,19 @@ class CoverageBuildActionTest {
 
     @Test
     void shouldReturnPositiveTrendForLineMetric() {
-        CoverageBuildAction action = createCoverageBuildActionWithDelta(Baseline.PROJECT, Metric.LINE, Optional.of(Fraction.getFraction(1,1000)));
+        CoverageBuildAction action = createCoverageBuildActionWithDelta(Baseline.PROJECT, Metric.LINE, Optional.of(Fraction.getFraction(1, 1000)));
         assertThat(action.getTrend(Baseline.PROJECT, Metric.LINE)).isPositive();
     }
 
     @Test
+    void shouldReturnNegativeTrendForLineMetric() {
+        CoverageBuildAction action = createCoverageBuildActionWithDelta(Baseline.PROJECT, Metric.LINE, Optional.of(Fraction.getFraction(-1, 1000)));
+        assertThat(action.getTrend(Baseline.PROJECT, Metric.LINE)).isNegative();
+    }
+
+    @Test
     void shouldReturnZeroForDeltaWithinBoundaries() {
-        CoverageBuildAction action = createCoverageBuildActionWithDelta(Baseline.PROJECT, Metric.LINE, Optional.of(Fraction.getFraction(9,10000)));
+        CoverageBuildAction action = createCoverageBuildActionWithDelta(Baseline.PROJECT, Metric.LINE, Optional.of(Fraction.getFraction(9, 10_000)));
         assertThat(action.getTrend(Baseline.PROJECT, Metric.LINE)).isZero();
     }
 

--- a/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildActionTest.java
+++ b/plugin/src/test/java/io/jenkins/plugins/coverage/metrics/steps/CoverageBuildActionTest.java
@@ -31,8 +31,7 @@ import static org.mockito.Mockito.*;
  */
 @DefaultLocale("en")
 class CoverageBuildActionTest {
-    @SuppressWarnings("unused")
-    private CoverageBuildAction createCoverageBuildActionWithDelta(final Baseline baseline, final Metric metric, final Optional<Fraction> delta) {
+    private CoverageBuildAction createCoverageBuildActionWithDelta(final Metric metric, final Optional<Fraction> delta) {
         Node module = new ModuleNode("module");
 
         var coverageBuilder = new CoverageBuilder();
@@ -111,25 +110,25 @@ class CoverageBuildActionTest {
 
     @Test
     void shouldReturnPositiveTrendForLineMetric() {
-        CoverageBuildAction action = createCoverageBuildActionWithDelta(Baseline.PROJECT, Metric.LINE, Optional.of(Fraction.getFraction(1, 1000)));
+        CoverageBuildAction action = createCoverageBuildActionWithDelta(Metric.LINE, Optional.of(Fraction.getFraction(1, 1000)));
         assertThat(action.getTrend(Baseline.PROJECT, Metric.LINE)).isPositive();
     }
 
     @Test
     void shouldReturnNegativeTrendForLineMetric() {
-        CoverageBuildAction action = createCoverageBuildActionWithDelta(Baseline.PROJECT, Metric.LINE, Optional.of(Fraction.getFraction(-1, 1000)));
+        CoverageBuildAction action = createCoverageBuildActionWithDelta(Metric.LINE, Optional.of(Fraction.getFraction(-1, 1000)));
         assertThat(action.getTrend(Baseline.PROJECT, Metric.LINE)).isNegative();
     }
 
     @Test
     void shouldReturnZeroForDeltaWithinBoundaries() {
-        CoverageBuildAction action = createCoverageBuildActionWithDelta(Baseline.PROJECT, Metric.LINE, Optional.of(Fraction.getFraction(9, 10_000)));
+        CoverageBuildAction action = createCoverageBuildActionWithDelta(Metric.LINE, Optional.of(Fraction.getFraction(9, 10_000)));
         assertThat(action.getTrend(Baseline.PROJECT, Metric.LINE)).isZero();
     }
 
     @Test
     void shouldReturnZeroWhenDeltaIsNotPresentForGivenMetric() {
-        CoverageBuildAction action = createCoverageBuildActionWithDelta(Baseline.PROJECT, Metric.LINE, Optional.empty());
+        CoverageBuildAction action = createCoverageBuildActionWithDelta(Metric.LINE, Optional.empty());
         assertThat(action.getTrend(Baseline.PROJECT, Metric.LINE)).isZero();
     }
 }


### PR DESCRIPTION
The previous boolean isPostiveTrend() is changed to int getTrend() and corresponding file changes are made as per the PR - Do not use color for unchanged coverage #777

### Testing done

#### I have added four test cases for the newly created getTrend() method:
- shouldReturnPositiveTrendForLineMetric()
- shouldReturnNegativeTrendForBranchMetric()
- shouldReturnZeroForZeroDelta()
- shouldReturnZeroWhenDeltaIsNotPresent()
